### PR TITLE
add tracker for x-ns and egress policies

### DIFF
--- a/pkg/backend/policy_tracker.go
+++ b/pkg/backend/policy_tracker.go
@@ -1,6 +1,9 @@
 package backend
 
 import (
+	"sync"
+
+	"github.com/aws/amazon-network-policy-controller-k8s/pkg/k8s"
 	"github.com/go-logr/logr"
 	networking "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -21,20 +24,70 @@ func NewPolicyTracker(logger logr.Logger) PolicyTracker {
 var _ PolicyTracker = (*defaultPolicyTracker)(nil)
 
 type defaultPolicyTracker struct {
+	logger              logr.Logger
+	namespacedPolicies  sync.Map
+	egressRulesPolicies sync.Map
 }
 
 func (t *defaultPolicyTracker) UpdatePolicy(policy *networking.NetworkPolicy) {
-	return
+	if t.containsNamespaceReference(policy) {
+		t.logger.V(1).Info("policy contains ns references", "policy", k8s.NamespacedName(policy))
+		t.namespacedPolicies.Store(k8s.NamespacedName(policy), true)
+	} else {
+		t.logger.V(1).Info("no ns references, remove", "policy", k8s.NamespacedName(policy))
+		t.namespacedPolicies.Delete(k8s.NamespacedName(policy))
+	}
+	if t.containsEgressRules(policy) {
+		t.logger.V(1).Info("policy contains egress rules", "policy", k8s.NamespacedName(policy))
+		t.egressRulesPolicies.Store(k8s.NamespacedName(policy), true)
+	} else {
+		t.logger.V(1).Info("no egress rules, remove tracking", "policy", k8s.NamespacedName(policy))
+		t.egressRulesPolicies.Delete(k8s.NamespacedName(policy))
+	}
 }
 
 func (t *defaultPolicyTracker) RemovePolicy(policy *networking.NetworkPolicy) {
-	return
+	t.logger.V(1).Info("remove from tracking", "policy", k8s.NamespacedName(policy))
+	t.namespacedPolicies.Delete(k8s.NamespacedName(policy))
+	t.egressRulesPolicies.Delete(k8s.NamespacedName(policy))
 }
 
 func (t *defaultPolicyTracker) GetPoliciesWithNamespaceReferences() sets.Set[types.NamespacedName] {
-	return nil
+	policies := sets.Set[types.NamespacedName]{}
+	t.namespacedPolicies.Range(func(k, _ interface{}) bool {
+		policies.Insert(k.(types.NamespacedName))
+		return true
+	})
+	return policies
 }
 
 func (t *defaultPolicyTracker) GetPoliciesWithEgressRules() sets.Set[types.NamespacedName] {
-	return nil
+	policies := sets.Set[types.NamespacedName]{}
+	t.egressRulesPolicies.Range(func(k, _ interface{}) bool {
+		policies.Insert(k.(types.NamespacedName))
+		return true
+	})
+	return policies
+}
+
+func (t *defaultPolicyTracker) containsNamespaceReference(policy *networking.NetworkPolicy) bool {
+	for _, ingRule := range policy.Spec.Ingress {
+		for _, peer := range ingRule.From {
+			if peer.NamespaceSelector != nil {
+				return true
+			}
+		}
+	}
+	for _, egrRule := range policy.Spec.Egress {
+		for _, peer := range egrRule.To {
+			if peer.NamespaceSelector != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (t *defaultPolicyTracker) containsEgressRules(policy *networking.NetworkPolicy) bool {
+	return len(policy.Spec.Egress) > 0
 }

--- a/pkg/backend/policy_tracker_test.go
+++ b/pkg/backend/policy_tracker_test.go
@@ -1,0 +1,308 @@
+package backend
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	networking "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func TestDefaultPolicyTracker_UpdatePolicy(t *testing.T) {
+	tests := []struct {
+		name           string
+		policies       []networking.NetworkPolicy
+		wantNsList     []types.NamespacedName
+		wantEgressList []types.NamespacedName
+	}{
+		{
+			name: "no namespace selector",
+			policies: []networking.NetworkPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "no-ns-selector",
+					},
+				},
+			},
+			wantEgressList: []types.NamespacedName{},
+			wantNsList:     []types.NamespacedName{},
+		},
+		{
+			name: "ns selector in ingress",
+			policies: []networking.NetworkPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress-selector",
+						Namespace: "app",
+					},
+					Spec: networking.NetworkPolicySpec{
+						Ingress: []networking.NetworkPolicyIngressRule{
+							{
+								From: []networking.NetworkPolicyPeer{
+									{
+										NamespaceSelector: &metav1.LabelSelector{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantNsList: []types.NamespacedName{
+				{
+					Namespace: "app",
+					Name:      "ingress-selector",
+				},
+			},
+			wantEgressList: []types.NamespacedName{},
+		},
+		{
+			name: "ns selector in egress",
+			policies: []networking.NetworkPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "egress-selector",
+						Namespace: "egress",
+					},
+					Spec: networking.NetworkPolicySpec{
+						Egress: []networking.NetworkPolicyEgressRule{
+							{
+								To: []networking.NetworkPolicyPeer{
+									{
+										NamespaceSelector: &metav1.LabelSelector{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantNsList: []types.NamespacedName{
+				{
+					Namespace: "egress",
+					Name:      "egress-selector",
+				},
+			},
+			wantEgressList: []types.NamespacedName{
+				{
+					Namespace: "egress",
+					Name:      "egress-selector",
+				},
+			},
+		},
+		{
+			name: "multiple entries",
+			policies: []networking.NetworkPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "no-ns-selector",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress-selector",
+						Namespace: "ing",
+					},
+					Spec: networking.NetworkPolicySpec{
+						Ingress: []networking.NetworkPolicyIngressRule{
+							{
+								From: []networking.NetworkPolicyPeer{
+									{
+										NamespaceSelector: &metav1.LabelSelector{},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "egress-selector",
+					},
+					Spec: networking.NetworkPolicySpec{
+						Egress: []networking.NetworkPolicyEgressRule{
+							{
+								To: []networking.NetworkPolicyPeer{
+									{
+										NamespaceSelector: &metav1.LabelSelector{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantNsList: []types.NamespacedName{
+				{
+					Namespace: "ing",
+					Name:      "ingress-selector",
+				},
+				{
+					Name: "egress-selector",
+				},
+			},
+			wantEgressList: []types.NamespacedName{
+				{
+					Name: "egress-selector",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policyTracker := &defaultPolicyTracker{
+				logger: logr.New(&log.NullLogSink{}),
+			}
+			for _, policy := range tt.policies {
+				policyTracker.UpdatePolicy(&policy)
+			}
+			gotNsList := policyTracker.GetPoliciesWithNamespaceReferences().UnsortedList()
+			gotEgressList := policyTracker.GetPoliciesWithEgressRules().UnsortedList()
+			for _, lst := range [][]types.NamespacedName{gotNsList, gotEgressList, tt.wantNsList, tt.wantEgressList} {
+				sort.Slice(lst, func(i, j int) bool {
+					return lst[i].String() < lst[j].String()
+				})
+			}
+			assert.Equal(t, tt.wantNsList, gotNsList)
+			assert.Equal(t, tt.wantEgressList, gotEgressList)
+		})
+	}
+}
+
+func TestDefaultPolicyTracker_RemovePolicy(t *testing.T) {
+	tests := []struct {
+		name                   string
+		existingNsRefPolicies  []types.NamespacedName
+		existingEgressPolicies []types.NamespacedName
+		policies               []networking.NetworkPolicy
+		wantNsList             []types.NamespacedName
+		wantEgressList         []types.NamespacedName
+	}{
+		{
+			name: "existing empty",
+			policies: []networking.NetworkPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "egress-selector",
+					},
+				},
+			},
+			wantNsList:     []types.NamespacedName{},
+			wantEgressList: []types.NamespacedName{},
+		},
+		{
+			name: "non tracked item delete",
+			existingNsRefPolicies: []types.NamespacedName{
+				{
+					Namespace: "awesome",
+					Name:      "app",
+				},
+			},
+			existingEgressPolicies: []types.NamespacedName{
+				{
+					Namespace: "awesome",
+					Name:      "egress",
+				},
+			},
+			policies: []networking.NetworkPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "egress-selector",
+					},
+				},
+			},
+			wantNsList: []types.NamespacedName{
+				{
+					Namespace: "awesome",
+					Name:      "app",
+				},
+			},
+			wantEgressList: []types.NamespacedName{
+				{
+					Namespace: "awesome",
+					Name:      "egress",
+				},
+			},
+		},
+		{
+			name: "tracked item delete",
+			existingNsRefPolicies: []types.NamespacedName{
+				{
+					Namespace: "awesome",
+					Name:      "app",
+				},
+				{
+					Namespace: "ing",
+					Name:      "policy",
+				},
+				{
+					Name: "egr",
+				},
+			},
+			existingEgressPolicies: []types.NamespacedName{
+				{
+					Name: "egr",
+				},
+				{
+					Name: "app",
+				},
+			},
+			policies: []networking.NetworkPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "app",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing",
+						Name:      "policy",
+					},
+				},
+			},
+			wantNsList: []types.NamespacedName{
+				{
+					Name: "egr",
+				},
+				{
+					Namespace: "awesome",
+					Name:      "app",
+				},
+			},
+			wantEgressList: []types.NamespacedName{
+				{
+					Name: "egr",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policyTracker := &defaultPolicyTracker{
+				logger: logr.New(&log.NullLogSink{}),
+			}
+			for _, entry := range tt.existingNsRefPolicies {
+				policyTracker.namespacedPolicies.Store(entry, true)
+			}
+			for _, entry := range tt.existingEgressPolicies {
+				policyTracker.egressRulesPolicies.Store(entry, true)
+			}
+			for _, policy := range tt.policies {
+				policyTracker.RemovePolicy(&policy)
+			}
+			gotNsList := policyTracker.GetPoliciesWithNamespaceReferences().UnsortedList()
+			gotEgressList := policyTracker.GetPoliciesWithEgressRules().UnsortedList()
+			for _, lst := range [][]types.NamespacedName{gotNsList, gotEgressList, tt.wantNsList, tt.wantEgressList} {
+				sort.Slice(lst, func(i, j int) bool {
+					return lst[i].String() < lst[j].String()
+				})
+			}
+			assert.Equal(t, tt.wantNsList, gotNsList)
+			assert.Equal(t, tt.wantEgressList, gotEgressList)
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
-->
**Description**
Add tracker for policies with namespace references and egress rules. This tacker is used during pod/service/namespace events to filter out the policies to consider for potential matches.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.