### PR TITLE
fix sync period handling, headless svc

### DIFF
--- a/internal/eventhandlers/policy.go
+++ b/internal/eventhandlers/policy.go
@@ -61,7 +61,7 @@ func (h *enqueueRequestForPolicyEvent) Update(_ context.Context, e event.UpdateE
 	newPolicy := e.ObjectNew.(*networking.NetworkPolicy)
 
 	h.logger.V(1).Info("Handling update event", "policy", k8s.NamespacedName(newPolicy))
-	if oldPolicy.Generation != newPolicy.Generation && equality.Semantic.DeepEqual(oldPolicy.Spec, newPolicy.Spec) &&
+	if !equality.Semantic.DeepEqual(newPolicy.ResourceVersion, oldPolicy.ResourceVersion) && equality.Semantic.DeepEqual(oldPolicy.Spec, newPolicy.Spec) &&
 		equality.Semantic.DeepEqual(oldPolicy.DeletionTimestamp.IsZero(), newPolicy.DeletionTimestamp.IsZero()) {
 		return
 	}

--- a/pkg/k8s/service_utils.go
+++ b/pkg/k8s/service_utils.go
@@ -42,3 +42,11 @@ func LookupListenPortFromPodSpec(svc *corev1.Service, pod *corev1.Pod, port ints
 	}
 	return 0, errors.Errorf("unable to find listener port for port %s on service %s", port.String(), NamespacedName(svc))
 }
+
+// IsServiceHeadless returns true if the service is headless
+func IsServiceHeadless(svc *corev1.Service) bool {
+	if svc.Spec.ClusterIP == "" || svc.Spec.ClusterIP == "None" {
+		return true
+	}
+	return false
+}

--- a/pkg/k8s/service_utils_test.go
+++ b/pkg/k8s/service_utils_test.go
@@ -305,3 +305,42 @@ func Test_LookupListenPortFromPodSpec(t *testing.T) {
 		})
 	}
 }
+
+func Test_IsServiceHeadless(t *testing.T) {
+	tests := []struct {
+		name string
+		svc  *corev1.Service
+		want bool
+	}{
+		{
+			name: "headless service",
+			svc: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					ClusterIP: corev1.ClusterIPNone,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "empty IP",
+			svc: &corev1.Service{
+				Spec: corev1.ServiceSpec{},
+			},
+			want: true,
+		},
+		{
+			name: "some cluster IP",
+			svc: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "10.100.0.209",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsServiceHeadless(tt.svc))
+		})
+	}
+
+}

--- a/pkg/resolvers/endpoints.go
+++ b/pkg/resolvers/endpoints.go
@@ -339,7 +339,7 @@ func (r *defaultEndpointsResolver) getMatchingServiceClusterIPs(ctx context.Cont
 		return nil
 	}
 	for _, svc := range svcList.Items {
-		if !svcSelector.Matches(labels.Set(svc.Spec.Selector)) {
+		if k8s.IsServiceHeadless(&svc) || !svcSelector.Matches(labels.Set(svc.Spec.Selector)) {
 			continue
 		}
 		var portList []policyinfo.Port

--- a/pkg/resolvers/endpoints_test.go
+++ b/pkg/resolvers/endpoints_test.go
@@ -373,6 +373,36 @@ func TestEndpointsResolver_Resolve(t *testing.T) {
 			},
 		},
 		{
+			name: "exclude headless service",
+			args: args{
+				netpol: egressPolicy,
+				podListCalls: []podListCall{
+					{
+						pods: []corev1.Pod{pod2, podNoIP, pod3},
+					},
+				},
+				serviceListCalls: []serviceListCall{
+					{
+						services: []corev1.Service{
+							{
+								Spec: corev1.ServiceSpec{
+									ClusterIP: "None",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantEgressEndpoints: []policyinfo.EndpointInfo{
+				{CIDR: "1.0.0.2"},
+				{CIDR: "1.0.0.3"},
+			},
+			wantPodEndpoints: []policyinfo.PodEndpoint{
+				{PodIP: "1.0.0.2", Name: "pod2", Namespace: "ns"},
+				{PodIP: "1.0.0.3", Name: "pod3", Namespace: "ns"},
+			},
+		},
+		{
 			name: "resolve network peers, ingress/egress",
 			args: args{
 				netpol: &networking.NetworkPolicy{

--- a/pkg/resolvers/policies_for_service.go
+++ b/pkg/resolvers/policies_for_service.go
@@ -16,7 +16,7 @@ import (
 
 // getReferredPoliciesForService returns the list of policies that refer to the service.
 func (r *defaultPolicyReferenceResolver) getReferredPoliciesForService(ctx context.Context, svc, svcOld *corev1.Service) ([]networking.NetworkPolicy, error) {
-	if svc.Spec.ClusterIP == "" || svc.Spec.ClusterIP == "None" {
+	if k8s.IsServiceHeadless(svc) {
 		r.logger.V(1).Info("Ignoring headless service", "svc", k8s.NamespacedName(svc))
 		return nil, nil
 	}


### PR DESCRIPTION
Fix policy event handler to refer resourceRevision do not include headless service in the endpoints
policyendpoints manager cleanup

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Description**
Fix policy event handler to refer resourceRevision to handle policy requeued after the sync period. Do not include headless service in the endpoints since headless service has the address `None` which is not a valid IP/CIDR. Cleanup policy endpoints manager.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.