### PR TITLE
update golang build image to 1.20.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY internal/ internal/
 
 # Version package for passing the ldflags
 # TODO: change this to network controller's version
-ENV VERSION_PKG=https://github.com/aws/amazon-network-policy-controller-k8s/pkg/version
+ENV VERSION_PKG=github.com/aws/amazon-network-policy-controller-k8s/pkg/version
 # Build
 RUN GIT_VERSION=$(git describe --tags --always) && \
         GIT_COMMIT=$(git rev-parse HEAD) && \

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ $(MOCKGEN): $(LOCALBIN)
 	test -s $(MOCKGEN) || GOBIN=$(LOCALBIN) go install github.com/golang/mock/mockgen@v1.6.0
 
 GOARCH=amd64
-BUILD_IMAGE=public.ecr.aws/docker/library/golang:1.20.5
+BUILD_IMAGE=public.ecr.aws/docker/library/golang:1.20.6
 BASE_IMAGE=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:latest.2
 GO_RUNNER_IMAGE=public.ecr.aws/eks-distro/kubernetes/go-runner:v0.15.0-eks-1-27-3
 .PHONY: docker-buildx

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/amazon-network-policy-controller-k8s
 
-go 1.19
+go 1.20
 
 require (
 	github.com/go-logr/logr v1.2.4
@@ -13,6 +13,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.1
 	go.uber.org/zap v1.24.0
+	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17
 	k8s.io/api v0.27.2
 	k8s.io/apimachinery v0.27.2
 	k8s.io/client-go v0.27.2
@@ -54,7 +55,6 @@ require (
 	github.com/prometheus/procfs v0.9.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 // indirect
 	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/oauth2 v0.5.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Description**
Update golang base image to 1.20.6. This addresses CVE-2023-29406.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.