### PR TITLE
refactor endpoint slice packing strategy

### DIFF
--- a/pkg/policyendpoints/manager.go
+++ b/pkg/policyendpoints/manager.go
@@ -128,139 +128,30 @@ func (m *policyEndpointsManager) computePolicyEndpoints(policy *networking.Netwo
 	existingPolicyEndpoints []policyinfo.PolicyEndpoint, ingressEndpoints []policyinfo.EndpointInfo,
 	egressEndpoints []policyinfo.EndpointInfo, podSelectorEndpoints []policyinfo.PodEndpoint) ([]policyinfo.PolicyEndpoint,
 	[]policyinfo.PolicyEndpoint, []policyinfo.PolicyEndpoint, error) {
+
+	// Loop through ingressEndpoints, egressEndpoints and podSelectorEndpoints and put in map
+	// also populate them into policy endpoints
+	ingressEndpointsMap, egressEndpointsMap, podSelectorEndpointSet, modifiedEndpoints, potentialDeletes := m.processExistingPolicyEndpoints(
+		policy, existingPolicyEndpoints, ingressEndpoints, egressEndpoints, podSelectorEndpoints,
+	)
+
+	doNotDelete := sets.Set[types.NamespacedName]{}
+
 	var createPolicyEndpoints []policyinfo.PolicyEndpoint
 	var updatePolicyEndpoints []policyinfo.PolicyEndpoint
 	var deletePolicyEndpoints []policyinfo.PolicyEndpoint
 
-	// Loop through ingressEndpoints, egressEndpoints and podSelectorEndpoints and put in map
-	ingressEndpointsMap := map[string]policyinfo.EndpointInfo{}
-	for _, ingressEndpoint := range ingressEndpoints {
-		ingressEndpointsMap[m.getEndpointInfoKey(ingressEndpoint)] = ingressEndpoint
-	}
-	egressEndpointsMap := map[string]policyinfo.EndpointInfo{}
-	for _, egressEndpoint := range egressEndpoints {
-		egressEndpointsMap[m.getEndpointInfoKey(egressEndpoint)] = egressEndpoint
-	}
-	podSelectorEndpointSet := sets.New[policyinfo.PodEndpoint](podSelectorEndpoints...)
-	// Go over the existing endpoints, and remove entries that are no longer needed
-	var modifiedEndpoints []policyinfo.PolicyEndpoint
-	var potentialDeletes []policyinfo.PolicyEndpoint
-	for i := range existingPolicyEndpoints {
-		ingEndpointList := make([]policyinfo.EndpointInfo, 0, len(existingPolicyEndpoints[i].Spec.Ingress))
-		for _, ingRule := range existingPolicyEndpoints[i].Spec.Ingress {
-			ruleKey := m.getEndpointInfoKey(ingRule)
-			if _, exists := ingressEndpointsMap[ruleKey]; exists {
-				ingEndpointList = append(ingEndpointList, ingRule)
-				delete(ingressEndpointsMap, ruleKey)
-			}
-		}
-		egEndpointList := make([]policyinfo.EndpointInfo, 0, len(existingPolicyEndpoints[i].Spec.Egress))
-		for _, egRule := range existingPolicyEndpoints[i].Spec.Egress {
-			ruleKey := m.getEndpointInfoKey(egRule)
-			if _, exists := egressEndpointsMap[ruleKey]; exists {
-				egEndpointList = append(egEndpointList, egRule)
-				delete(egressEndpointsMap, ruleKey)
-			}
-		}
-		podSelectorEndpointList := make([]policyinfo.PodEndpoint, 0, len(existingPolicyEndpoints[i].Spec.PodSelectorEndpoints))
-		for _, ps := range existingPolicyEndpoints[i].Spec.PodSelectorEndpoints {
-			if podSelectorEndpointSet.Has(ps) {
-				podSelectorEndpointList = append(podSelectorEndpointList, ps)
-				podSelectorEndpointSet.Delete(ps)
-			}
-		}
-		policyEndpointChanged := false
-		if !equality.Semantic.DeepEqual(policy.Spec.PolicyTypes, existingPolicyEndpoints[i].Spec.PodIsolation) {
-			existingPolicyEndpoints[i].Spec.PodIsolation = policy.Spec.PolicyTypes
-			policyEndpointChanged = true
-		}
+	// packing new ingress rules
+	createPolicyEndpoints, doNotDeleteIngress := m.packingIngressRules(policy, ingressEndpointsMap, createPolicyEndpoints, modifiedEndpoints, potentialDeletes)
+	// packing new egress rules
+	createPolicyEndpoints, doNotDeleteEgress := m.packingEgressRules(policy, egressEndpointsMap, createPolicyEndpoints, modifiedEndpoints, potentialDeletes)
+	// packing new pod selector
+	createPolicyEndpoints, doNotDeletePs := m.packingPodSelectors(policy, podSelectorEndpointSet.UnsortedList(), createPolicyEndpoints, modifiedEndpoints, potentialDeletes)
 
-		if len(ingEndpointList) == 0 && len(egEndpointList) == 0 && len(podSelectorEndpointList) == 0 {
-			existingPolicyEndpoints[i].Spec.Ingress = ingEndpointList
-			existingPolicyEndpoints[i].Spec.Egress = egEndpointList
-			existingPolicyEndpoints[i].Spec.PodSelectorEndpoints = podSelectorEndpointList
-			potentialDeletes = append(potentialDeletes, existingPolicyEndpoints[i])
-		} else if len(existingPolicyEndpoints[i].Spec.Ingress) != len(ingEndpointList) || len(existingPolicyEndpoints[i].Spec.Egress) != len(egEndpointList) ||
-			len(existingPolicyEndpoints[i].Spec.PodSelectorEndpoints) != len(podSelectorEndpointList) || policyEndpointChanged {
-			existingPolicyEndpoints[i].Spec.Ingress = ingEndpointList
-			existingPolicyEndpoints[i].Spec.Egress = egEndpointList
-			existingPolicyEndpoints[i].Spec.PodSelectorEndpoints = podSelectorEndpointList
-			modifiedEndpoints = append(modifiedEndpoints, existingPolicyEndpoints[i])
-		} else {
-			modifiedEndpoints = append(modifiedEndpoints, existingPolicyEndpoints[i])
-		}
-	}
+	doNotDelete.Insert(doNotDeleteIngress.UnsortedList()...)
+	doNotDelete.Insert(doNotDeleteEgress.UnsortedList()...)
+	doNotDelete.Insert(doNotDeletePs.UnsortedList()...)
 
-	ingressRuleChunks := lo.Chunk(maps.Keys(ingressEndpointsMap), m.endpointChunkSize)
-	doNotDelete := sets.Set[types.NamespacedName]{}
-	for _, chunk := range ingressRuleChunks {
-		// check in the existing lists if chunk fits, otherwise allocate a new ep
-		var assigned bool
-		for _, sliceToCheck := range [][]policyinfo.PolicyEndpoint{createPolicyEndpoints, modifiedEndpoints, potentialDeletes} {
-			for i := range sliceToCheck {
-				if m.endpointChunkSize-len(sliceToCheck[i].Spec.Ingress) >= len(chunk) {
-					sliceToCheck[i].Spec.Ingress = append(sliceToCheck[i].Spec.Ingress, m.getListOfEndpointInfoFromHash(chunk, ingressEndpointsMap)...)
-					doNotDelete.Insert(k8s.NamespacedName(&sliceToCheck[i]))
-					assigned = true
-					break
-				}
-			}
-			if assigned {
-				break
-			}
-		}
-		if assigned {
-			continue
-		}
-		newEP := m.newPolicyEndpoint(policy, m.getListOfEndpointInfoFromHash(chunk, ingressEndpointsMap), nil, nil)
-		createPolicyEndpoints = append(createPolicyEndpoints, newEP)
-	}
-
-	egressRuleChunks := lo.Chunk(maps.Keys(egressEndpointsMap), m.endpointChunkSize)
-	for _, chunk := range egressRuleChunks {
-		// check in the existing to-update/to-delete list if chunk fits, otherwise allocate a new ep
-		var assigned bool
-		for _, sliceToCheck := range [][]policyinfo.PolicyEndpoint{createPolicyEndpoints, modifiedEndpoints, potentialDeletes} {
-			for i := range sliceToCheck {
-				if m.endpointChunkSize-len(sliceToCheck[i].Spec.Egress) >= len(chunk) {
-					sliceToCheck[i].Spec.Egress = append(sliceToCheck[i].Spec.Egress, m.getListOfEndpointInfoFromHash(chunk, egressEndpointsMap)...)
-					doNotDelete.Insert(k8s.NamespacedName(&sliceToCheck[i]))
-					assigned = true
-					break
-				}
-			}
-			if assigned {
-				break
-			}
-		}
-		if assigned {
-			continue
-		}
-		newEP := m.newPolicyEndpoint(policy, nil, m.getListOfEndpointInfoFromHash(chunk, egressEndpointsMap), nil)
-		createPolicyEndpoints = append(createPolicyEndpoints, newEP)
-	}
-	podEndpointChunks := lo.Chunk(podSelectorEndpointSet.UnsortedList(), m.endpointChunkSize)
-	for _, chunk := range podEndpointChunks {
-		var assigned bool
-		for _, sliceToCheck := range [][]policyinfo.PolicyEndpoint{createPolicyEndpoints, modifiedEndpoints, potentialDeletes} {
-			for i := range sliceToCheck {
-				if m.endpointChunkSize-len(sliceToCheck[i].Spec.PodSelectorEndpoints) >= len(chunk) {
-					sliceToCheck[i].Spec.PodSelectorEndpoints = append(sliceToCheck[i].Spec.PodSelectorEndpoints, chunk...)
-					doNotDelete.Insert(k8s.NamespacedName(&sliceToCheck[i]))
-					assigned = true
-					break
-				}
-			}
-			if assigned {
-				break
-			}
-		}
-		if assigned {
-			continue
-		}
-		newEP := m.newPolicyEndpoint(policy, nil, nil, chunk)
-		createPolicyEndpoints = append(createPolicyEndpoints, newEP)
-	}
 	for _, ep := range potentialDeletes {
 		if doNotDelete.Has(k8s.NamespacedName(&ep)) {
 			updatePolicyEndpoints = append(updatePolicyEndpoints, ep)
@@ -280,7 +171,58 @@ func (m *policyEndpointsManager) computePolicyEndpoints(policy *networking.Netwo
 		}
 	}
 
+	updatePolicyEndpoints, deletePolicyEndpoints = m.compressPolicyEndpoints(updatePolicyEndpoints, deletePolicyEndpoints)
+
 	return createPolicyEndpoints, updatePolicyEndpoints, deletePolicyEndpoints, nil
+}
+
+// compressPolicyEndpoints further compresses the endpoints to ensure every PE being packed with full size if possible.
+func (m *policyEndpointsManager) compressPolicyEndpoints(update, delete []policyinfo.PolicyEndpoint) ([]policyinfo.PolicyEndpoint, []policyinfo.PolicyEndpoint) {
+	var ingressRules []policyinfo.EndpointInfo
+	var egressRules []policyinfo.EndpointInfo
+	var podSelectorEndpoints []policyinfo.PodEndpoint
+
+	for _, u := range update {
+		ingressRules = append(ingressRules, u.Spec.Ingress...)
+		egressRules = append(egressRules, u.Spec.Egress...)
+		podSelectorEndpoints = append(podSelectorEndpoints, u.Spec.PodSelectorEndpoints...)
+		u.Spec.Ingress = nil
+		u.Spec.Egress = nil
+		u.Spec.PodSelectorEndpoints = nil
+	}
+
+	ingressChunks := lo.Chunk(ingressRules, m.endpointChunkSize)
+	egressChunks := lo.Chunk(egressRules, m.endpointChunkSize)
+	podSelectorChunks := lo.Chunk(podSelectorEndpoints, m.endpointChunkSize)
+
+	i := 0
+	e := 0
+	p := 0
+
+	var compressedUpdate []policyinfo.PolicyEndpoint
+
+	for _, u := range update {
+		// either one of the policies has items, we compress them to the updated PE
+		if i < len(ingressChunks) || e < len(egressChunks) || p < len(podSelectorChunks) {
+			if i < len(ingressChunks) {
+				u.Spec.Ingress = ingressChunks[i]
+				i++
+			}
+			if e < len(egressChunks) {
+				u.Spec.Egress = egressChunks[e]
+				e++
+			}
+			if p < len(podSelectorChunks) {
+				u.Spec.PodSelectorEndpoints = podSelectorChunks[p]
+				p++
+			}
+			compressedUpdate = append(compressedUpdate, u)
+		} else {
+			// otherwise, we delete the empty PE
+			delete = append(delete, u)
+		}
+	}
+	return compressedUpdate, delete
 }
 
 func (m *policyEndpointsManager) newPolicyEndpoint(policy *networking.NetworkPolicy,
@@ -347,4 +289,204 @@ func (m *policyEndpointsManager) getEndpointInfoKey(info policyinfo.EndpointInfo
 		}
 	}
 	return hex.EncodeToString(hasher.Sum(nil))
+}
+
+// processExistingPolicyEndpoints processes the existing policies with the coming network policy changes
+// it returned required rules and pod selector changes, and potential modifications and deletions on policy endpoints.
+func (m *policyEndpointsManager) processExistingPolicyEndpoints(
+	policy *networking.NetworkPolicy,
+	existingPolicyEndpoints []policyinfo.PolicyEndpoint, ingressEndpoints []policyinfo.EndpointInfo,
+	egressEndpoints []policyinfo.EndpointInfo, podSelectorEndpoints []policyinfo.PodEndpoint,
+) (
+	map[string]policyinfo.EndpointInfo,
+	map[string]policyinfo.EndpointInfo,
+	sets.Set[policyinfo.PodEndpoint],
+	[]policyinfo.PolicyEndpoint,
+	[]policyinfo.PolicyEndpoint,
+) {
+
+	// Loop through ingressEndpoints, egressEndpoints and podSelectorEndpoints and put in map
+	ingressEndpointsMap := map[string]policyinfo.EndpointInfo{}
+	for _, ingressEndpoint := range ingressEndpoints {
+		ingressEndpointsMap[m.getEndpointInfoKey(ingressEndpoint)] = ingressEndpoint
+	}
+	egressEndpointsMap := map[string]policyinfo.EndpointInfo{}
+	for _, egressEndpoint := range egressEndpoints {
+		egressEndpointsMap[m.getEndpointInfoKey(egressEndpoint)] = egressEndpoint
+	}
+	podSelectorEndpointSet := sets.New[policyinfo.PodEndpoint](podSelectorEndpoints...)
+	// Go over the existing endpoints, and remove entries that are no longer needed
+	var modifiedEndpoints []policyinfo.PolicyEndpoint
+	var potentialDeletes []policyinfo.PolicyEndpoint
+	for i := range existingPolicyEndpoints {
+		ingEndpointList := make([]policyinfo.EndpointInfo, 0, len(existingPolicyEndpoints[i].Spec.Ingress))
+		for _, ingRule := range existingPolicyEndpoints[i].Spec.Ingress {
+			ruleKey := m.getEndpointInfoKey(ingRule)
+			if _, exists := ingressEndpointsMap[ruleKey]; exists {
+				ingEndpointList = append(ingEndpointList, ingRule)
+				delete(ingressEndpointsMap, ruleKey)
+			}
+		}
+		egEndpointList := make([]policyinfo.EndpointInfo, 0, len(existingPolicyEndpoints[i].Spec.Egress))
+		for _, egRule := range existingPolicyEndpoints[i].Spec.Egress {
+			ruleKey := m.getEndpointInfoKey(egRule)
+			if _, exists := egressEndpointsMap[ruleKey]; exists {
+				egEndpointList = append(egEndpointList, egRule)
+				delete(egressEndpointsMap, ruleKey)
+			}
+		}
+		podSelectorEndpointList := make([]policyinfo.PodEndpoint, 0, len(existingPolicyEndpoints[i].Spec.PodSelectorEndpoints))
+		for _, ps := range existingPolicyEndpoints[i].Spec.PodSelectorEndpoints {
+			if podSelectorEndpointSet.Has(ps) {
+				podSelectorEndpointList = append(podSelectorEndpointList, ps)
+				podSelectorEndpointSet.Delete(ps)
+			}
+		}
+		policyEndpointChanged := false
+		if !equality.Semantic.DeepEqual(policy.Spec.PolicyTypes, existingPolicyEndpoints[i].Spec.PodIsolation) {
+			existingPolicyEndpoints[i].Spec.PodIsolation = policy.Spec.PolicyTypes
+			policyEndpointChanged = true
+		}
+
+		if len(ingEndpointList) == 0 && len(egEndpointList) == 0 && len(podSelectorEndpointList) == 0 {
+			existingPolicyEndpoints[i].Spec.Ingress = ingEndpointList
+			existingPolicyEndpoints[i].Spec.Egress = egEndpointList
+			existingPolicyEndpoints[i].Spec.PodSelectorEndpoints = podSelectorEndpointList
+			potentialDeletes = append(potentialDeletes, existingPolicyEndpoints[i])
+		} else if len(existingPolicyEndpoints[i].Spec.Ingress) != len(ingEndpointList) || len(existingPolicyEndpoints[i].Spec.Egress) != len(egEndpointList) ||
+			len(existingPolicyEndpoints[i].Spec.PodSelectorEndpoints) != len(podSelectorEndpointList) || policyEndpointChanged {
+			existingPolicyEndpoints[i].Spec.Ingress = ingEndpointList
+			existingPolicyEndpoints[i].Spec.Egress = egEndpointList
+			existingPolicyEndpoints[i].Spec.PodSelectorEndpoints = podSelectorEndpointList
+			modifiedEndpoints = append(modifiedEndpoints, existingPolicyEndpoints[i])
+		} else {
+			modifiedEndpoints = append(modifiedEndpoints, existingPolicyEndpoints[i])
+		}
+	}
+	return ingressEndpointsMap, egressEndpointsMap, podSelectorEndpointSet, modifiedEndpoints, potentialDeletes
+}
+
+// packingIngressRules iterates over ingress rules across available policy endpoints and required ingress rule changes.
+// it returns the ingress rules packed in policy endpoints and a set of policy endpoints that need to be kept.
+func (m *policyEndpointsManager) packingIngressRules(policy *networking.NetworkPolicy,
+	rulesMap map[string]policyinfo.EndpointInfo,
+	createPolicyEndpoints, modifiedEndpoints, potentialDeletes []policyinfo.PolicyEndpoint) ([]policyinfo.PolicyEndpoint, sets.Set[types.NamespacedName]) {
+	doNotDelete := sets.Set[types.NamespacedName]{}
+	chunkStartIdx := 0
+	chunkEndIdx := 0
+	ingressList := maps.Keys(rulesMap)
+	for _, sliceToCheck := range [][]policyinfo.PolicyEndpoint{createPolicyEndpoints, modifiedEndpoints, potentialDeletes} {
+		for i := range sliceToCheck {
+			// reset start pointer if end pointer is updated
+			chunkStartIdx = chunkEndIdx
+			// Instead of adding the entire chunk we should try to add to full the slice
+			if len(sliceToCheck[i].Spec.Ingress) < m.endpointChunkSize && chunkEndIdx < len(ingressList) {
+				for len(sliceToCheck[i].Spec.Ingress)+(chunkEndIdx-chunkStartIdx+1) < m.endpointChunkSize && chunkEndIdx < len(ingressList)-1 {
+					chunkEndIdx++
+				}
+
+				sliceToCheck[i].Spec.Ingress = append(sliceToCheck[i].Spec.Ingress, m.getListOfEndpointInfoFromHash(lo.Slice(ingressList, chunkStartIdx, chunkEndIdx+1), rulesMap)...)
+				// move the end to next available index to prepare next appending
+				chunkEndIdx++
+			}
+			// as long as the second pointer moves, we need to include the PE
+			if chunkStartIdx != chunkEndIdx {
+				doNotDelete.Insert(k8s.NamespacedName(&sliceToCheck[i]))
+			}
+		}
+	}
+
+	// if the incoming ingress rules haven't been all processed yet, we need new PE(s).
+	if chunkEndIdx < len(ingressList) {
+		ingressRuleChunks := lo.Chunk(ingressList[chunkEndIdx:], m.endpointChunkSize)
+		for _, chunk := range ingressRuleChunks {
+			newEP := m.newPolicyEndpoint(policy, m.getListOfEndpointInfoFromHash(chunk, rulesMap), nil, nil)
+			createPolicyEndpoints = append(createPolicyEndpoints, newEP)
+		}
+	}
+	return createPolicyEndpoints, doNotDelete
+}
+
+// packingEgressRules iterates over egress rules across available policy endpoints and required egress rule changes.
+// it returns the egress rules packed in policy endpoints and a set of policy endpoints that need to be kept.
+func (m *policyEndpointsManager) packingEgressRules(policy *networking.NetworkPolicy,
+	rulesMap map[string]policyinfo.EndpointInfo,
+	createPolicyEndpoints, modifiedEndpoints, potentialDeletes []policyinfo.PolicyEndpoint) ([]policyinfo.PolicyEndpoint, sets.Set[types.NamespacedName]) {
+	// ingressRuleChunks := lo.Chunk(maps.Keys(ingressEndpointsMap), m.endpointChunkSize)
+	doNotDelete := sets.Set[types.NamespacedName]{}
+	chunkStartIdx := 0
+	chunkEndIdx := 0
+	egressList := maps.Keys(rulesMap)
+	for _, sliceToCheck := range [][]policyinfo.PolicyEndpoint{createPolicyEndpoints, modifiedEndpoints, potentialDeletes} {
+		for i := range sliceToCheck {
+			// reset start pointer if end pointer is updated
+			chunkStartIdx = chunkEndIdx
+			// Instead of adding the entire chunk we should try to add to full the slice
+			if len(sliceToCheck[i].Spec.Egress) < m.endpointChunkSize && chunkEndIdx < len(egressList) {
+				for len(sliceToCheck[i].Spec.Egress)+(chunkEndIdx-chunkStartIdx+1) < m.endpointChunkSize && chunkEndIdx < len(egressList)-1 {
+					chunkEndIdx++
+				}
+
+				sliceToCheck[i].Spec.Egress = append(sliceToCheck[i].Spec.Egress, m.getListOfEndpointInfoFromHash(lo.Slice(egressList, chunkStartIdx, chunkEndIdx+1), rulesMap)...)
+				// move the end to next available index to prepare next appending
+				chunkEndIdx++
+			}
+			// as long as the second pointer moves, we need to include the PE
+			if chunkStartIdx != chunkEndIdx {
+				doNotDelete.Insert(k8s.NamespacedName(&sliceToCheck[i]))
+			}
+		}
+	}
+
+	// if the incoming ingress rules haven't been all processed yet, we need new PE(s).
+	if chunkEndIdx < len(egressList) {
+		egressRuleChunks := lo.Chunk(egressList[chunkEndIdx:], m.endpointChunkSize)
+		for _, chunk := range egressRuleChunks {
+			newEP := m.newPolicyEndpoint(policy, nil, m.getListOfEndpointInfoFromHash(chunk, rulesMap), nil)
+			createPolicyEndpoints = append(createPolicyEndpoints, newEP)
+		}
+	}
+	return createPolicyEndpoints, doNotDelete
+}
+
+// packingPodSelectors iterates over pod selectors across available policy endpoints and required pod selector changes.
+// it returns the pod selectors packed in policy endpoints and a set of policy endpoints that need to be kept.
+func (m *policyEndpointsManager) packingPodSelectors(policy *networking.NetworkPolicy,
+	psList []policyinfo.PodEndpoint,
+	createPolicyEndpoints, modifiedEndpoints, potentialDeletes []policyinfo.PolicyEndpoint) ([]policyinfo.PolicyEndpoint, sets.Set[types.NamespacedName]) {
+
+	doNotDelete := sets.Set[types.NamespacedName]{}
+	chunkStartIdx := 0
+	chunkEndIdx := 0
+
+	for _, sliceToCheck := range [][]policyinfo.PolicyEndpoint{createPolicyEndpoints, modifiedEndpoints, potentialDeletes} {
+		for i := range sliceToCheck {
+			// reset start pointer if end pointer is updated
+			chunkStartIdx = chunkEndIdx
+			// Instead of adding the entire chunk we should try to add to full the slice
+			if len(sliceToCheck[i].Spec.PodSelectorEndpoints) < m.endpointChunkSize && chunkEndIdx < len(psList) {
+				for len(sliceToCheck[i].Spec.PodSelectorEndpoints)+(chunkEndIdx-chunkStartIdx+1) < m.endpointChunkSize && chunkEndIdx < len(psList)-1 {
+					chunkEndIdx++
+				}
+
+				sliceToCheck[i].Spec.PodSelectorEndpoints = append(sliceToCheck[i].Spec.PodSelectorEndpoints, lo.Slice(psList, chunkStartIdx, chunkEndIdx+1)...)
+				// move the end to next available index to prepare next appending
+				chunkEndIdx++
+			}
+			// as long as the second pointer moves, we need to include the PE
+			if chunkStartIdx != chunkEndIdx {
+				doNotDelete.Insert(k8s.NamespacedName(&sliceToCheck[i]))
+			}
+		}
+	}
+
+	// if the incoming podselectors haven't been all processed yet, we need new PE(s).
+	if chunkEndIdx < len(psList) {
+		psChunks := lo.Chunk(psList[chunkEndIdx:], m.endpointChunkSize)
+		for _, chunk := range psChunks {
+			newEP := m.newPolicyEndpoint(policy, nil, nil, chunk)
+			createPolicyEndpoints = append(createPolicyEndpoints, newEP)
+		}
+	}
+	return createPolicyEndpoints, doNotDelete
 }

--- a/pkg/resolvers/policy_tracker.go
+++ b/pkg/resolvers/policy_tracker.go
@@ -47,7 +47,7 @@ func (t *defaultPolicyTracker) UpdatePolicy(policy *networking.NetworkPolicy) {
 	}
 }
 
-// RemovePolicy removes the given policy from the policy tracker during during deletion
+// RemovePolicy removes the given policy from the policy tracker during deletion
 func (t *defaultPolicyTracker) RemovePolicy(policy *networking.NetworkPolicy) {
 	t.logger.V(1).Info("remove from tracking", "policy", k8s.NamespacedName(policy))
 	t.namespacedPolicies.Delete(k8s.NamespacedName(policy))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
improvement
**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:
Currently we pack endpoints of rules and pods to splitted slices based on configured chunk size. The issue is slices are packed eventually and unbounded growing when doing frequent resources scaling. We want to implement bin packing to ensure the slices are evenly packed and slice number growing expect-able and manage-able.

**If an issue # is not available please add steps to reproduce and the controller logs**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
The change has been tested with rules and pods by scaling up/down. The slices were verified being filled evenly and bin packed.

For example:
chunk size is 5

```
% k scale deploy nginx --replicas=5                                                      
deployment.apps/nginx scaled
% k get policyendpoint -ojson | jq -r '.items[].spec.podSelectorEndpoints | length'      
5
% k scale deploy nginx --replicas=15                                                
deployment.apps/nginx scaled
% k get policyendpoint -ojson | jq -r '.items[].spec.podSelectorEndpoints | length' 
5
5
5
% k scale deploy nginx --replicas=17                                                
deployment.apps/nginx scaled
% k get policyendpoint -ojson | jq -r '.items[].spec.podSelectorEndpoints | length' 
5
5
2
5
% k scale deploy nginx --replicas=15                                                
deployment.apps/nginx scaled
% k get policyendpoint -ojson | jq -r '.items[].spec.podSelectorEndpoints | length' 
5
5
5
% k scale deploy nginx --replicas=11                                                
deployment.apps/nginx scaled
% k get policyendpoint -ojson | jq -r '.items[].spec.podSelectorEndpoints | length' 
1
5
5
% k scale deploy nginx --replicas=5                                                 
deployment.apps/nginx scaled
% k get policyendpoint -ojson | jq -r '.items[].spec.podSelectorEndpoints | length' 
5

```

**Automation added to e2e**:
<!--
List the e2e tests you added as part of this PR.
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new K8s API
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.