### PR TITLE
Revert label commit and update golang to v1.21.5

### DIFF
--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.4'
+          go-version: '1.21.5'
           cache-dependency-path: "**/go.sum"
       - name: Install `govulncheck`
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ $(MOCKGEN): $(LOCALBIN)
 	test -s $(MOCKGEN) || GOBIN=$(LOCALBIN) go install github.com/golang/mock/mockgen@v1.6.0
 
 GOARCH=amd64
-BUILD_IMAGE=public.ecr.aws/docker/library/golang:1.21.4
+BUILD_IMAGE=public.ecr.aws/docker/library/golang:1.21.3
 BASE_IMAGE=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:latest.2
 GO_RUNNER_IMAGE=public.ecr.aws/eks-distro/kubernetes/go-runner:v0.15.0-eks-1-27-3
 .PHONY: docker-buildx

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ $(MOCKGEN): $(LOCALBIN)
 	test -s $(MOCKGEN) || GOBIN=$(LOCALBIN) go install github.com/golang/mock/mockgen@v1.6.0
 
 GOARCH=amd64
-BUILD_IMAGE=public.ecr.aws/docker/library/golang:1.21.3
+BUILD_IMAGE=public.ecr.aws/docker/library/golang:1.21.5
 BASE_IMAGE=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:latest.2
 GO_RUNNER_IMAGE=public.ecr.aws/eks-distro/kubernetes/go-runner:v0.15.0-eks-1-27-3
 .PHONY: docker-buildx

--- a/pkg/policyendpoints/manager.go
+++ b/pkg/policyendpoints/manager.go
@@ -23,10 +23,6 @@ import (
 	"github.com/aws/amazon-network-policy-controller-k8s/pkg/resolvers"
 )
 
-const (
-	LabelKeyToParentPolicyName = "networking.k8s.io/parent-network-policy-name"
-)
-
 type PolicyEndpointsManager interface {
 	Reconcile(ctx context.Context, policy *networking.NetworkPolicy) error
 	Cleanup(ctx context.Context, policy *networking.NetworkPolicy) error
@@ -192,9 +188,6 @@ func (m *policyEndpointsManager) newPolicyEndpoint(policy *networking.NetworkPol
 					BlockOwnerDeletion: &blockOwnerDeletion,
 					Controller:         &isController,
 				},
-			},
-			Labels: map[string]string{
-				LabelKeyToParentPolicyName: policy.Name,
 			},
 		},
 		Spec: policyinfo.PolicyEndpointSpec{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
bug
**Which issue does this PR fix**:
#59 

**What does this PR do / Why do we need it**:
We revert a label improvement which can cause PE creation failure when using long name for its network policy.

**If an issue # is not available please add steps to reproduce and the controller logs**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!--
List the e2e tests you added as part of this PR.
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new K8s API
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.