### PR TITLE
Enabling logs in critical paths

### DIFF
--- a/internal/controllers/policy_controller.go
+++ b/internal/controllers/policy_controller.go
@@ -122,7 +122,7 @@ func (r *policyReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manage
 func (r *policyReconciler) reconcile(ctx context.Context, request reconcile.Request) error {
 	policy := &networking.NetworkPolicy{}
 	if err := r.k8sClient.Get(ctx, request.NamespacedName, policy); err != nil {
-		r.logger.V(1).Info("Unable to get policy", "resource", policy, "err", err)
+		r.logger.Info("Unable to get policy", "resource", policy, "err", err)
 		return client.IgnoreNotFound(err)
 	}
 	if !policy.DeletionTimestamp.IsZero() {

--- a/pkg/resolvers/endpoints_test.go
+++ b/pkg/resolvers/endpoints_test.go
@@ -830,7 +830,6 @@ func TestEndpointsResolver_ResolveNetworkPeers(t *testing.T) {
 		)
 
 		for _, rule := range policy.Spec.Egress {
-			resolver.logger.V(1).Info("computing egress addresses", "peers", rule.To)
 			if rule.To == nil {
 				egressEndpoints = append(egressEndpoints, resolver.getAllowAllNetworkPeers(rule.Ports)...)
 				continue

--- a/pkg/resolvers/policies_for_service.go
+++ b/pkg/resolvers/policies_for_service.go
@@ -17,7 +17,7 @@ import (
 // getReferredPoliciesForService returns the list of policies that refer to the service.
 func (r *defaultPolicyReferenceResolver) getReferredPoliciesForService(ctx context.Context, svc, svcOld *corev1.Service) ([]networking.NetworkPolicy, error) {
 	if k8s.IsServiceHeadless(svc) {
-		r.logger.V(1).Info("Ignoring headless service", "svc", k8s.NamespacedName(svc))
+		r.logger.Info("Ignoring headless service", "svc", k8s.NamespacedName(svc))
 		return nil, nil
 	}
 	policiesWithEgressRules := r.policyTracker.GetPoliciesWithEgressRules()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
cleanup
**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:
Since we are running this controller in EKS managed control plane, we should enable critical logs by default.

**If an issue # is not available please add steps to reproduce and the controller logs**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Ran the controller locally and confirmed.
**Automation added to e2e**:
<!--
List the e2e tests you added as part of this PR.
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new K8s API
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.