### PR TITLE
fix a duplicated ingress port issue

### DIFF
--- a/pkg/resolvers/endpoints.go
+++ b/pkg/resolvers/endpoints.go
@@ -224,10 +224,10 @@ func (r *defaultEndpointsResolver) getIngressRulesPorts(ctx context.Context, pol
 	}
 
 	// since we pull ports from dst pods, we should deduplicate them
-	deduppedPorts := dedupPorts(portList)
-	r.logger.Info("Got ingress ports from dst pods", "port", deduppedPorts)
+	dedupedPorts := dedupPorts(portList)
+	r.logger.Info("Got ingress ports from dst pods", "port", dedupedPorts)
 
-	return deduppedPorts
+	return dedupedPorts
 }
 
 func (r *defaultEndpointsResolver) getPortList(pod corev1.Pod, ports []networking.NetworkPolicyPort) []policyinfo.Port {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
bug
**Which issue does this PR fix**:
This PR is fixing the duplicated ingress ports issue when scale dst pods.

**What does this PR do / Why do we need it**:
The bug can cause duplicated ports breaching the limit and fails ports beyond the limit.

**If an issue # is not available please add steps to reproduce and the controller logs**:
1, create two deployments (simple nginx) with replicas = 1
2, create NPs for one deployment pods with ingress from the other deployment pods
3, scale the dst pods to a larger number
4, print out the policyendpoint and check if the ingress has duplicated ports with a same cidr in one entry

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Before this fix
```
  ingress:
  - cidr: 192.168.163.178
    ports:
    - port: 80
      protocol: TCP
    - port: 80
      protocol: TCP
    - port: 80
      protocol: TCP
  podIsolation:
  - Ingress
  - Egress
```
after this fix
```
  ingress:
  - cidr: 192.168.51.76
    ports:
    - port: 80
      protocol: TCP
  podIsolation:
  - Ingress
  - Egress
```
with more than one port
```
  ingress:
  - cidr: 192.168.7.80
    ports:
    - port: 80
      protocol: TCP
    - port: 8080
      protocol: TCP
  podIsolation:
  - Ingress
  - Egress
```

Updated Unit Tests
Before the fix
```
Error Trace:	/local/home/zhuhz/go/src/amazon-network-policy-controller-k8s/pkg/resolvers/endpoints_test.go:872
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	TestEndpointsResolver_ResolveNetworkPeers
```
After the fix
```
=== RUN   TestEndpointsResolver_ResolveNetworkPeers
--- PASS: TestEndpointsResolver_ResolveNetworkPeers (0.00s)
PASS
ok      github.com/aws/amazon-network-policy-controller-k8s/pkg/resolvers       (cached)
```

**Automation added to e2e**:
<!--
List the e2e tests you added as part of this PR.
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new K8s API
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.