### PR TITLE
add prometheus metrics to count PE resolving errors

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/aws/amazon-network-policy-controller-k8s/pkg/config"
 	"github.com/aws/amazon-network-policy-controller-k8s/pkg/k8s"
 	"github.com/aws/amazon-network-policy-controller-k8s/pkg/policyendpoints"
+	"github.com/aws/amazon-network-policy-controller-k8s/pkg/prometheus"
 	"github.com/aws/amazon-network-policy-controller-k8s/pkg/utils/configmap"
 	"github.com/aws/amazon-network-policy-controller-k8s/pkg/version"
 	//+kubebuilder:scaffold:imports
@@ -90,6 +91,9 @@ func main() {
 	setupLog.Info("Checking args for PE chunk size", "PEChunkSize", controllerCFG.EndpointChunkSize)
 	setupLog.Info("Checking args for policy batch time", "NPBatchTime", controllerCFG.PodUpdateBatchPeriodDuration)
 	setupLog.Info("Checking args for reconciler count", "ReconcilerCount", controllerCFG.MaxConcurrentReconciles)
+
+	setupLog.Info("Register metrics in promethus")
+	prometheus.RegisterPrometheus()
 
 	if controllerCFG.EnableConfigMapCheck {
 		var cancelFn context.CancelFunc

--- a/pkg/policyendpoints/manager.go
+++ b/pkg/policyendpoints/manager.go
@@ -20,6 +20,7 @@ import (
 
 	policyinfo "github.com/aws/amazon-network-policy-controller-k8s/api/v1alpha1"
 	"github.com/aws/amazon-network-policy-controller-k8s/pkg/k8s"
+	"github.com/aws/amazon-network-policy-controller-k8s/pkg/prometheus"
 	"github.com/aws/amazon-network-policy-controller-k8s/pkg/resolvers"
 )
 
@@ -51,6 +52,7 @@ type policyEndpointsManager struct {
 func (m *policyEndpointsManager) Reconcile(ctx context.Context, policy *networking.NetworkPolicy) error {
 	ingressRules, egressRules, podSelectorEndpoints, err := m.endpointsResolver.Resolve(ctx, policy)
 	if err != nil {
+		prometheus.ResolveNetworkPolicyEndpointsErrCnt.Inc()
 		return err
 	}
 
@@ -107,6 +109,7 @@ func (m *policyEndpointsManager) Cleanup(ctx context.Context, policy *networking
 	if err := m.k8sClient.List(ctx, policyEndpointList,
 		client.InNamespace(policy.Namespace),
 		client.MatchingLabels{IndexKeyPolicyReferenceName: policy.Name}); err != nil {
+		prometheus.CleanupNetworkPolicyEndpointsErrCnt.Inc()
 		return errors.Wrap(err, "unable to list policyendpoints")
 	}
 	for _, policyEndpoint := range policyEndpointList.Items {

--- a/pkg/prometheus/metrics.go
+++ b/pkg/prometheus/metrics.go
@@ -1,0 +1,53 @@
+package prometheus
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	CleanupNetworkPolicyEndpointsErrCnt = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "cleanup_network_policy_endpoints_err_count",
+			Help: "The number of errors encountered while cleaning up network policy endpoints",
+		},
+	)
+
+	ResolveNetworkPolicyEndpointsErrCnt = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "resolve_network_policy_endpoints_err_count",
+			Help: "The number of errors encountered while resolving network policy endpoints",
+		},
+	)
+
+	ComputeIngressEndpointsErrCnt = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "compute_ingress_endpoints_err_count",
+			Help: "The number of errors encountered while computing ingress endpoints",
+		},
+	)
+
+	ComputeEgressEndpointsErrCnt = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "compute_egress_endpoints_err_count",
+			Help: "The number of errors encountered while computing egress endpoints",
+		},
+	)
+
+	ComputePodEndpointsErrCnt = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "compute_pod_endpoints_err_count",
+			Help: "The number of errors encountered while computing pod endpoints",
+		},
+	)
+)
+
+func RegisterPrometheus() {
+	metrics.Registry.MustRegister(
+		CleanupNetworkPolicyEndpointsErrCnt,
+		ResolveNetworkPolicyEndpointsErrCnt,
+		ComputeIngressEndpointsErrCnt,
+		ComputeEgressEndpointsErrCnt,
+		ComputePodEndpointsErrCnt,
+	)
+}

--- a/pkg/resolvers/endpoints.go
+++ b/pkg/resolvers/endpoints.go
@@ -7,6 +7,7 @@ import (
 
 	policyinfo "github.com/aws/amazon-network-policy-controller-k8s/api/v1alpha1"
 	"github.com/aws/amazon-network-policy-controller-k8s/pkg/k8s"
+	"github.com/aws/amazon-network-policy-controller-k8s/pkg/prometheus"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"golang.org/x/exp/maps"
@@ -44,14 +45,17 @@ func (r *defaultEndpointsResolver) Resolve(ctx context.Context, policy *networki
 	[]policyinfo.EndpointInfo, []policyinfo.PodEndpoint, error) {
 	ingressEndpoints, err := r.computeIngressEndpoints(ctx, policy)
 	if err != nil {
+		prometheus.ComputeIngressEndpointsErrCnt.Inc()
 		return nil, nil, nil, err
 	}
 	egressEndpoints, err := r.computeEgressEndpoints(ctx, policy)
 	if err != nil {
+		prometheus.ComputeEgressEndpointsErrCnt.Inc()
 		return nil, nil, nil, err
 	}
 	podSelectorEndpoints, err := r.computePodSelectorEndpoints(ctx, policy)
 	if err != nil {
+		prometheus.ComputePodEndpointsErrCnt.Inc()
 		return nil, nil, nil, err
 	}
 	r.logger.Info("Resolved endpoints", "policy", k8s.NamespacedName(policy), "ingress", len(ingressEndpoints), "egress",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
improvement
**Which issue does this PR fix**:
Add prometheus support for customized metrics. In this PR, we add metrics from policy endpoints resolving errors.

**What does this PR do / Why do we need it**:
We should have better observability on how policy endpoints have been resolved.

**If an issue # is not available please add steps to reproduce and the controller logs**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Tested in dev cluster with a new deployment.
```
# HELP cleanup_network_policy_endpoints_err_count The number of errors encountered while cleaning up network policy endpoints
# TYPE cleanup_network_policy_endpoints_err_count counter
cleanup_network_policy_endpoints_err_count 0
# HELP compute_egress_endpoints_err_count The number of errors encountered while computing egress endpoints
# TYPE compute_egress_endpoints_err_count counter
compute_egress_endpoints_err_count 0
# HELP compute_ingress_endpoints_err_count The number of errors encountered while computing ingress endpoints
# TYPE compute_ingress_endpoints_err_count counter
compute_ingress_endpoints_err_count 0
# HELP compute_pod_endpoints_err_count The number of errors encountered while computing pod endpoints
# TYPE compute_pod_endpoints_err_count counter
compute_pod_endpoints_err_count 0
```
**Automation added to e2e**:
<!--
List the e2e tests you added as part of this PR.
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new K8s API
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.