### PR TITLE
optimize memory usage by striping down the runtime cache

### DIFF
--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,15 +18,18 @@ package main
 
 import (
 	"context"
+	"net/http"
+	"os"
+
 	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
 	"go.uber.org/zap/zapcore"
-	"net/http"
-	"os"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	_ "net/http/pprof"
+
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,15 +18,15 @@ package main
 
 import (
 	"context"
-	"os"
-
 	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
 	"go.uber.org/zap/zapcore"
-
+	"net/http"
+	"os"
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	_ "net/http/pprof"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -148,6 +148,15 @@ func main() {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
+
+	if controllerCFG.EnableGoProfiling {
+		go func() {
+			if err := http.ListenAndServe("localhost:6060", nil); err != nil {
+				setupLog.Error(err, "Error starting HTTP server")
+			}
+		}()
+	}
+
 	setupLog.Info("starting controller manager")
 	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running controller manager")

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,8 @@ require (
 )
 
 require (
+	github.com/aws/aws-sdk-go-v2 v1.36.0 // indirect
+	github.com/aws/smithy-go v1.22.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,9 @@
+github.com/aws/aws-sdk-go-v2 v1.25.1 h1:P7hU6A5qEdmajGwvae/zDkOq+ULLC9tQBTwqqiwFGpI=
+github.com/aws/aws-sdk-go-v2 v1.25.1/go.mod h1:Evoc5AsmtveRt1komDwIsjHFyrP5tDuF1D1U+6z6pNo=
+github.com/aws/aws-sdk-go-v2 v1.36.0 h1:b1wM5CcE65Ujwn565qcwgtOTT1aT4ADOHHgglKjG7fk=
+github.com/aws/aws-sdk-go-v2 v1.36.0/go.mod h1:5PMILGVKiW32oDzjj6RU52yrNrDPUHcbZQYr1sM7qmM=
+github.com/aws/smithy-go v1.22.2 h1:6D9hW43xKFrRx/tXXfAlIZc4JI+yQe6snnWcQyxSyLQ=
+github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/pkg/config/controller_config.go
+++ b/pkg/config/controller_config.go
@@ -11,12 +11,14 @@ const (
 	flagMaxConcurrentReconciles      = "max-concurrent-reconciles"
 	flagEnableConfigMapCheck         = "enable-configmap-check"
 	flagEndpointChunkSize            = "endpoint-chunk-size"
+	flagEnableGoProfiling            = "enable-goprofiling"
 	defaultLogLevel                  = "info"
 	defaultMaxConcurrentReconciles   = 3
 	defaultEndpointsChunkSize        = 200
 	defaultEnableConfigMapCheck      = true
 	flagPodUpdateBatchPeriodDuration = "pod-update-batch-period-duration"
 	defaultBatchPeriodDuration       = 1 * time.Second
+	defaultEnableGoProfiling         = false
 )
 
 // ControllerConfig contains the controller configuration
@@ -33,6 +35,8 @@ type ControllerConfig struct {
 	PodUpdateBatchPeriodDuration time.Duration
 	// Configurations for the Controller Runtime
 	RuntimeConfig RuntimeConfig
+	// EnableGoProfiling enables the goprofiling for dev purpose
+	EnableGoProfiling bool
 }
 
 func (cfg *ControllerConfig) BindFlags(fs *pflag.FlagSet) {
@@ -46,5 +50,7 @@ func (cfg *ControllerConfig) BindFlags(fs *pflag.FlagSet) {
 		"Enable checking the configmap for starting the network policy controller")
 	fs.DurationVar(&cfg.PodUpdateBatchPeriodDuration, flagPodUpdateBatchPeriodDuration, defaultBatchPeriodDuration, ""+
 		"Duration between batch updates of pods")
+	fs.BoolVar(&cfg.EnableGoProfiling, flagEnableGoProfiling, defaultEnableGoProfiling,
+		"Enable goprofiling for develop purpose")
 	cfg.RuntimeConfig.BindFlags(fs)
 }

--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -1,11 +1,12 @@
 package config
 
 import (
+	"time"
+
 	"github.com/aws/amazon-network-policy-controller-k8s/pkg/k8s"
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	networkingv1 "k8s.io/api/networking/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"time"
 
+	"github.com/aws/amazon-network-policy-controller-k8s/api/v1alpha1"
 	"github.com/aws/amazon-network-policy-controller-k8s/pkg/k8s"
 	networkingv1 "k8s.io/api/networking/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -101,7 +102,7 @@ func BuildCacheOptions() cache.Options {
 			&corev1.Namespace{}:           {},
 			&networkingv1.NetworkPolicy{}: {},
 			&corev1.Endpoints{}:           {},
-			&corev1.ConfigMap{}:           {},
+			&v1alpha1.PolicyEndpoint{}:    {},
 		},
 	}
 	return cacheOptions

--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -1,6 +1,10 @@
 package config
 
 import (
+	"github.com/aws/amazon-network-policy-controller-k8s/pkg/k8s"
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	networkingv1 "k8s.io/api/networking/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -82,15 +86,36 @@ func BuildRestConfig(rtCfg RuntimeConfig) (*rest.Config, error) {
 	return restCFG, nil
 }
 
+// BuildCacheOptions returns a cache.Options struct for this controller.
+func BuildCacheOptions() cache.Options {
+	cacheOptions := cache.Options{
+		ReaderFailOnMissingInformer: true,
+		ByObject: map[client.Object]cache.ByObject{
+			&corev1.Pod{}: {
+				// the controller does not mutate pod objects, thus we can safely disable DeepCopy for pod objects to optimize memory usage.
+				UnsafeDisableDeepCopy: awssdk.Bool(true),
+				Transform:             k8s.StripDownPodTransformFunc,
+			},
+			&corev1.Service{}: {
+				//the controller does not mutate service objects, thus we can safely disable DeepCopy for service objects to optimize memory usage.
+				UnsafeDisableDeepCopy: awssdk.Bool(true),
+				Transform:             k8s.StripDownServiceTransformFunc,
+			},
+			&corev1.Namespace{}:           {},
+			&networkingv1.NetworkPolicy{}: {},
+			&corev1.Endpoints{}:           {},
+		},
+	}
+	return cacheOptions
+}
+
 // BuildRuntimeOptions builds the options for the controller runtime based on config
 func BuildRuntimeOptions(rtCfg RuntimeConfig, scheme *runtime.Scheme) ctrl.Options {
-	// if DefaultNamespaces in Options is not set, cache will watch for all namespaces
-	cacheOptions := cache.Options{}
+	cacheOptions := BuildCacheOptions()
+	// if WatchNamespace in Options is not set, cache will watch for all namespaces
 	if rtCfg.WatchNamespace != corev1.NamespaceAll {
-		cacheOptions = cache.Options{
-			DefaultNamespaces: map[string]cache.Config{
-				rtCfg.WatchNamespace: {},
-			},
+		cacheOptions.DefaultNamespaces = map[string]cache.Config{
+			rtCfg.WatchNamespace: {},
 		}
 	}
 	return ctrl.Options{

--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/aws/amazon-network-policy-controller-k8s/pkg/k8s"
-	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	networkingv1 "k8s.io/api/networking/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -70,6 +69,7 @@ func (c *RuntimeConfig) BindFlags(fs *pflag.FlagSet) {
 }
 
 // BuildRestConfig builds the REST config for the controller runtime
+// Note: the ByObject opts should include all the objects that the controller watches for
 func BuildRestConfig(rtCfg RuntimeConfig) (*rest.Config, error) {
 	var restCFG *rest.Config
 	var err error
@@ -93,18 +93,15 @@ func BuildCacheOptions() cache.Options {
 		ReaderFailOnMissingInformer: true,
 		ByObject: map[client.Object]cache.ByObject{
 			&corev1.Pod{}: {
-				// the controller does not mutate pod objects, thus we can safely disable DeepCopy for pod objects to optimize memory usage.
-				UnsafeDisableDeepCopy: awssdk.Bool(true),
-				Transform:             k8s.StripDownPodTransformFunc,
+				Transform: k8s.StripDownPodTransformFunc,
 			},
 			&corev1.Service{}: {
-				//the controller does not mutate service objects, thus we can safely disable DeepCopy for service objects to optimize memory usage.
-				UnsafeDisableDeepCopy: awssdk.Bool(true),
-				Transform:             k8s.StripDownServiceTransformFunc,
+				Transform: k8s.StripDownServiceTransformFunc,
 			},
 			&corev1.Namespace{}:           {},
 			&networkingv1.NetworkPolicy{}: {},
 			&corev1.Endpoints{}:           {},
+			&corev1.ConfigMap{}:           {},
 		},
 	}
 	return cacheOptions

--- a/pkg/config/runtime_config_test.go
+++ b/pkg/config/runtime_config_test.go
@@ -1,0 +1,13 @@
+package config
+
+import (
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+func Test_buildCacheOptions(t *testing.T) {
+	cacheOptions := BuildCacheOptions()
+	g := NewWithT(t)
+	g.Expect(cacheOptions.ReaderFailOnMissingInformer).To(BeTrue())
+	g.Expect(cacheOptions.ByObject).To(HaveLen(2))
+}

--- a/pkg/config/runtime_config_test.go
+++ b/pkg/config/runtime_config_test.go
@@ -10,5 +10,5 @@ func Test_buildCacheOptions(t *testing.T) {
 	cacheOptions := BuildCacheOptions()
 	g := NewWithT(t)
 	g.Expect(cacheOptions.ReaderFailOnMissingInformer).To(BeTrue())
-	g.Expect(cacheOptions.ByObject).To(HaveLen(5))
+	g.Expect(cacheOptions.ByObject).To(HaveLen(6))
 }

--- a/pkg/config/runtime_config_test.go
+++ b/pkg/config/runtime_config_test.go
@@ -1,13 +1,14 @@
 package config
 
 import (
-	. "github.com/onsi/gomega"
 	"testing"
+
+	. "github.com/onsi/gomega"
 )
 
 func Test_buildCacheOptions(t *testing.T) {
 	cacheOptions := BuildCacheOptions()
 	g := NewWithT(t)
 	g.Expect(cacheOptions.ReaderFailOnMissingInformer).To(BeTrue())
-	g.Expect(cacheOptions.ByObject).To(HaveLen(2))
+	g.Expect(cacheOptions.ByObject).To(HaveLen(5))
 }

--- a/pkg/k8s/pod_utils.go
+++ b/pkg/k8s/pod_utils.go
@@ -55,9 +55,7 @@ func StripDownPodTransformFunc(obj interface{}) (interface{}, error) {
 }
 
 // stripDownPodObject provides an stripDown version of pod to reduce memory usage.
-// NOTE: if the controller needs to refer to more pod fields in the future
-//
-//	these fields need to be added to the cache
+// NOTE: if the controller needs to refer to more pod fields in the future these fields need to be added to the cache
 func stripDownPodObject(pod *corev1.Pod) *corev1.Pod {
 	pod.ObjectMeta = metav1.ObjectMeta{
 		Name:              pod.Name,

--- a/pkg/k8s/pod_utils.go
+++ b/pkg/k8s/pod_utils.go
@@ -68,7 +68,7 @@ func stripDownPodObject(pod *corev1.Pod) *corev1.Pod {
 		Finalizers:        pod.Finalizers,
 	}
 	// Extract only the Name and Ports in spec.Container
-	var strippedContainers []corev1.Container
+	strippedContainers := make([]corev1.Container, 0, len(pod.Spec.Containers))
 	for _, container := range pod.Spec.Containers {
 		strippedContainers = append(strippedContainers, corev1.Container{
 			Name:  container.Name,

--- a/pkg/k8s/service_utils.go
+++ b/pkg/k8s/service_utils.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -49,4 +50,38 @@ func IsServiceHeadless(svc *corev1.Service) bool {
 		return true
 	}
 	return false
+}
+
+// StripDownServiceTransformFunc is a transform function that strips down service to reduce memory usage.
+// see details in [stripDownServiceObject].
+func StripDownServiceTransformFunc(obj interface{}) (interface{}, error) {
+	if service, ok := obj.(*corev1.Service); ok {
+		return stripDownServiceObject(service), nil
+	}
+	return obj, nil
+}
+
+// stripDownServiceObject provides an stripDown version of service to reduce memory usage.
+// NOTE: if the controller needs to refer to more service fields in the future
+// these fields need to be added to the cache
+func stripDownServiceObject(service *corev1.Service) *corev1.Service {
+	service.ObjectMeta = metav1.ObjectMeta{
+		Name:              service.Name,
+		Namespace:         service.Namespace,
+		UID:               service.UID,
+		DeletionTimestamp: service.DeletionTimestamp,
+		ResourceVersion:   service.ResourceVersion,
+		Finalizers:        service.Finalizers,
+	}
+	service.Spec = corev1.ServiceSpec{
+		Selector:   service.Spec.Selector,
+		ClusterIP:  service.Spec.ClusterIP,
+		ClusterIPs: service.Spec.ClusterIPs,
+		Ports:      service.Spec.Ports,
+		Type:       service.Spec.Type,
+	}
+	service.Status = corev1.ServiceStatus{
+		LoadBalancer: service.Status.LoadBalancer,
+	}
+	return service
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
-->
**What type of PR is this?**
Improvement

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
The NP controller watches for pods and services in all namespaces, and was caching the whole objects in the controller runtime cache. It may lead to significant memory usage when the scale of pods/services go up. For the controller itself, it does not need all the fields but just selective fields of the objects. 

This PR introduces a strip down func for these objects, as well as disable the deep copy of the pod and service objects. With stripdown, we only cache these fields:
For pod:
- metadata: name, namespace, UID, labels, annotations, deletionTimestamp, resourceVersion, finalizers
- container: name and ports
- status: HostIP, HostIPs, PodIP and PodIPs

For service:
- metadata: name, namespace, UID, deletionTimestamp, resourceVersion, finalizers
- spec: selector, clusterIP, clusterIPs, ports and type
- status: loadBalancer

This PR also adds a flag to enable goprofiling, for development purpose to profiling the resource usage of the controller. 

**What does this PR do / Why do we need it**:
To avoid unnecessary memory usage that may lead to OOM killed and leave controller in crashbackloop

**If an issue # is not available please add steps to reproduce and the controller logs**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!--
List the e2e tests you added as part of this PR.
If no, create an issue with enhancement/testing label
-->
#### 1. scale test with 10k pods, 3k service and 3k networkpolicy
####     memory usage reduced by ~60% from 700MB+ to 200+MB, an example
memory profiling before optimization:
```
(pprof) top
Showing nodes accounting for 683.78MB, 94.03% of 727.17MB total
Dropped 152 nodes (cum <= 3.64MB)
Showing top 10 nodes out of 71
      flat  flat%   sum%        cum   cum%
  190.71MB 26.23% 26.23%   190.71MB 26.23%  k8s.io/apimachinery/pkg/apis/meta/v1.(*FieldsV1).Unmarshal
  127.84MB 17.58% 43.81%   320.55MB 44.08%  k8s.io/apimachinery/pkg/apis/meta/v1.(*ObjectMeta).Unmarshal
  127.45MB 17.53% 61.33%   188.46MB 25.92%  k8s.io/api/core/v1.(*Container).Unmarshal
   87.24MB 12.00% 73.33%    87.24MB 12.00%  reflect.unsafe_NewArray
   59.50MB  8.18% 81.51%    59.50MB  8.18%  k8s.io/api/core/v1.(*EnvVar).Unmarshal
   39.50MB  5.43% 86.95%       44MB  6.05%  sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).literalStore
   23.52MB  3.23% 90.18%    23.52MB  3.23%  reflect.New
   14.01MB  1.93% 92.11%    20.51MB  2.82%  k8s.io/api/core/v1.(*PodStatus).Unmarshal
   10.50MB  1.44% 93.55%   208.96MB 28.74%  k8s.io/api/core/v1.(*PodSpec).Unmarshal
    3.50MB  0.48% 94.03%        7MB  0.96%  k8s.io/api/core/v1.(*ProjectedVolumeSource).Unmarshal
```
memory profiling after optimization
```
(pprof) top
Showing nodes accounting for 233.31MB, 94.81% of 246.07MB total
Dropped 98 nodes (cum <= 1.23MB)
Showing top 10 nodes out of 94
      flat  flat%   sum%        cum   cum%
   80.19MB 32.59% 32.59%    81.19MB 33.00%  k8s.io/apimachinery/pkg/apis/meta/v1.(*ObjectMeta).Unmarshal
   71.06MB 28.88% 61.47%    71.06MB 28.88%  reflect.unsafe_NewArray
   36.50MB 14.83% 76.30%    42.50MB 17.27%  sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).literalStore
   28.02MB 11.39% 87.69%    28.02MB 11.39%  reflect.New
    7.50MB  3.05% 90.74%     7.50MB  3.05%  github.com/aws/amazon-network-policy-controller-k8s/pkg/k8s.stripDownPodObject (inline)
    3.50MB  1.42% 92.16%     3.50MB  1.42%  k8s.io/apimachinery/pkg/apis/meta/v1.(*LabelSelector).Unmarshal
       2MB  0.81% 92.97%        2MB  0.81%  k8s.io/api/core/v1.(*ServiceSpec).Unmarshal
    1.53MB  0.62% 93.59%     9.53MB  3.87%  k8s.io/client-go/tools/cache.(*DeltaFIFO).queueActionInternalLocked
    1.50MB  0.61% 94.20%     1.50MB  0.61%  k8s.io/apimachinery/pkg/util/sets.Set[go.shape.string].Insert
    1.50MB  0.61% 94.81%     1.50MB  0.61%  reflect.mapassign_faststr0
```

#### 2. cyclonus test Passed
[Cyclonus test result](https://paste.amazon.com/show/sonyingy/1738952676)

**Will this PR introduce any new dependencies?**:
<!--
e.g. new K8s API
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
NA
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.