### PR TITLE
remve unneeded v1 endpoints from cache

### DIFF
--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -101,7 +101,6 @@ func BuildCacheOptions() cache.Options {
 			},
 			&corev1.Namespace{}:           {},
 			&networkingv1.NetworkPolicy{}: {},
-			&corev1.Endpoints{}:           {},
 			&v1alpha1.PolicyEndpoint{}:    {},
 		},
 	}

--- a/pkg/config/runtime_config_test.go
+++ b/pkg/config/runtime_config_test.go
@@ -10,5 +10,5 @@ func Test_buildCacheOptions(t *testing.T) {
 	cacheOptions := BuildCacheOptions()
 	g := NewWithT(t)
 	g.Expect(cacheOptions.ReaderFailOnMissingInformer).To(BeTrue())
-	g.Expect(cacheOptions.ByObject).To(HaveLen(6))
+	g.Expect(cacheOptions.ByObject).To(HaveLen(5))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
bug
**Which issue does this PR fix**:
the NPC does not need v1 endpoint Object. remove this object from runtime cache options.

**What does this PR do / Why do we need it**:


**If an issue # is not available please add steps to reproduce and the controller logs**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!--
List the e2e tests you added as part of this PR.
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new K8s API
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.