### PR TITLE
update go runner image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN GIT_VERSION=$(git describe --tags --always) && \
 FROM $BASE_IMAGE
 
 WORKDIR /
-COPY --from=public.ecr.aws/eks-distro/kubernetes/go-runner:v0.15.0-eks-1-27-3 /go-runner /usr/local/bin/go-runner
+COPY --from=public.ecr.aws/eks-distro/kubernetes/go-runner:v0.18.0-eks-1-32-10 /go-runner /usr/local/bin/go-runner
 COPY --from=builder /workspace/controller .
 USER 65532:65532
 

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ $(MOCKGEN): $(LOCALBIN)
 GO_IMAGE_TAG=$(shell cat .go-version)
 BUILD_IMAGE=public.ecr.aws/docker/library/golang:$(GO_IMAGE_TAG)
 BASE_IMAGE=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:latest.2
-GO_RUNNER_IMAGE=public.ecr.aws/eks-distro/kubernetes/go-runner:v0.15.0-eks-1-27-3
+GO_RUNNER_IMAGE=public.ecr.aws/eks-distro/kubernetes/go-runner:v0.18.0-eks-1-32-10
 .PHONY: docker-buildx
 docker-buildx: test
 	for platform in $(ARCHS); do \


### PR DESCRIPTION
Updated the `go-runner` image to patch various CVEs. 


## Before

```
usr/local/bin/go-runner (gobinary)
==================================
Total: 26 (UNKNOWN: 1, LOW: 0, MEDIUM: 18, HIGH: 6, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────────┬──────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │          Fixed Version           │                            Title                             │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-24790 │ CRITICAL │ fixed  │ v1.19.9           │ 1.21.11, 1.22.4                  │ golang: net/netip: Unexpected behavior from Is methods for   │
│         │                │          │        │                   │                                  │ IPv4-mapped IPv6 addresses                                   │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2024-24790                   │
│         ├────────────────┼──────────┤        │                   ├──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2023-29403 │ HIGH     │        │                   │ 1.19.10, 1.20.5                  │ golang: runtime: unexpected behavior of setuid/setgid        │
│         │                │          │        │                   │                                  │ binaries                                                     │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-29403                   │
│         ├────────────────┤          │        │                   ├──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2023-39325 │          │        │                   │ 1.20.10, 1.21.3                  │ golang: net/http, x/net/http2: rapid stream resets can cause │
│         │                │          │        │                   │                                  │ excessive work (CVE-2023-44487)                              │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-39325                   │
│         ├────────────────┤          │        │                   ├──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2023-45283 │          │        │                   │ 1.20.11, 1.21.4, 1.20.12, 1.21.5 │ The filepath package does not recognize paths with a \??\    │
│         │                │          │        │                   │                                  │ prefix as...                                                 │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-45283                   │
│         ├────────────────┤          │        │                   ├──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2023-45287 │          │        │                   │ 1.20.0                           │ golang: crypto/tls: Timing Side Channel attack in RSA based  │
│         │                │          │        │                   │                                  │ TLS key exchanges....                                        │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-45287                   │
│         ├────────────────┤          │        │                   ├──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2023-45288 │          │        │                   │ 1.21.9, 1.22.2                   │ golang: net/http, x/net/http2: unlimited number of           │
│         │                │          │        │                   │                                  │ CONTINUATION frames causes DoS                               │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-45288                   │
│         ├────────────────┤          │        │                   ├──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2024-34156 │          │        │                   │ 1.22.7, 1.23.1                   │ encoding/gob: golang: Calling Decoder.Decode on a message    │
│         │                │          │        │                   │                                  │ which contains deeply nested structures...                   │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2024-34156                   │
│         ├────────────────┼──────────┤        │                   ├──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2023-29406 │ MEDIUM   │        │                   │ 1.19.11, 1.20.6                  │ golang: net/http: insufficient sanitization of Host header   │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-29406                   │
│         ├────────────────┤          │        │                   ├──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2023-29409 │          │        │                   │ 1.19.12, 1.20.7, 1.21.0-rc.4     │ golang: crypto/tls: slow verification of certificate chains  │
│         │                │          │        │                   │                                  │ containing large RSA keys                                    │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-29409                   │
│         ├────────────────┤          │        │                   ├──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2023-39318 │          │        │                   │ 1.20.8, 1.21.1                   │ golang: html/template: improper handling of HTML-like        │
│         │                │          │        │                   │                                  │ comments within script contexts                              │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-39318                   │
│         ├────────────────┤          │        │                   │                                  ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2023-39319 │          │        │                   │                                  │ golang: html/template: improper handling of special tags     │
│         │                │          │        │                   │                                  │ within script contexts                                       │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-39319                   │
│         ├────────────────┤          │        │                   ├──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2023-39326 │          │        │                   │ 1.20.12, 1.21.5                  │ golang: net/http/internal: Denial of Service (DoS) via       │
│         │                │          │        │                   │                                  │ Resource Consumption via HTTP requests...                    │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-39326                   │
│         ├────────────────┤          │        │                   ├──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2023-45284 │          │        │                   │ 1.20.11, 1.21.4                  │ On Windows, The IsLocal function does not correctly detect   │
│         │                │          │        │                   │                                  │ reserved de ......                                           │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-45284                   │
│         ├────────────────┤          │        │                   ├──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2023-45289 │          │        │                   │ 1.21.8, 1.22.1                   │ golang: net/http/cookiejar: incorrect forwarding of          │
│         │                │          │        │                   │                                  │ sensitive headers and cookies on HTTP redirect...            │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-45289                   │
│         ├────────────────┤          │        │                   │                                  ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2023-45290 │          │        │                   │                                  │ golang: net/http: golang: mime/multipart: golang:            │
│         │                │          │        │                   │                                  │ net/textproto: memory exhaustion in                          │
│         │                │          │        │                   │                                  │ Request.ParseMultipartForm                                   │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-45290                   │
│         ├────────────────┤          │        │                   │                                  ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2024-24783 │          │        │                   │                                  │ golang: crypto/x509: Verify panics on certificates with an   │
│         │                │          │        │                   │                                  │ unknown public key algorithm...                              │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2024-24783                   │
│         ├────────────────┤          │        │                   │                                  ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2024-24784 │          │        │                   │                                  │ golang: net/mail: comments in display names are incorrectly  │
│         │                │          │        │                   │                                  │ handled                                                      │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2024-24784                   │
│         ├────────────────┤          │        │                   │                                  ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2024-24785 │          │        │                   │                                  │ golang: html/template: errors returned from MarshalJSON      │
│         │                │          │        │                   │                                  │ methods may break template escaping                          │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2024-24785                   │
│         ├────────────────┤          │        │                   ├──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2024-24789 │          │        │                   │ 1.21.11, 1.22.4                  │ golang: archive/zip: Incorrect handling of certain ZIP files │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2024-24789                   │
│         ├────────────────┤          │        │                   ├──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2024-24791 │          │        │                   │ 1.21.12, 1.22.5                  │ net/http: Denial of service due to improper 100-continue     │
│         │                │          │        │                   │                                  │ handling in net/http                                         │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2024-24791                   │
│         ├────────────────┤          │        │                   ├──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2024-34155 │          │        │                   │ 1.22.7, 1.23.1                   │ go/parser: golang: Calling any of the Parse functions        │
│         │                │          │        │                   │                                  │ containing deeply nested literals...                         │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2024-34155                   │
│         ├────────────────┤          │        │                   │                                  ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2024-34158 │          │        │                   │                                  │ go/build/constraint: golang: Calling Parse on a "// +build"  │
│         │                │          │        │                   │                                  │ build tag line with...                                       │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2024-34158                   │
│         ├────────────────┤          │        │                   ├──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2024-45336 │          │        │                   │ 1.22.11, 1.23.5, 1.24.0-rc.2     │ golang: net/http: net/http: sensitive headers incorrectly    │
│         │                │          │        │                   │                                  │ sent after cross-domain redirect                             │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2024-45336                   │
│         ├────────────────┤          │        │                   │                                  ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2024-45341 │          │        │                   │                                  │ golang: crypto/x509: crypto/x509: usage of IPv6 zone IDs can │
│         │                │          │        │                   │                                  │ bypass URI name...                                           │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2024-45341                   │
│         ├────────────────┤          │        │                   ├──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2025-22866 │          │        │                   │ 1.22.12, 1.23.6, 1.24.0-rc.3     │ crypto/internal/nistec: golang: Timing sidechannel for P-256 │
│         │                │          │        │                   │                                  │ on ppc64le in crypto/internal/nistec                         │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2025-22866                   │
│         ├────────────────┼──────────┤        │                   ├──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2025-22871 │ UNKNOWN  │        │                   │ 1.23.8, 1.24.2                   │ Request smuggling due to acceptance of invalid chunked data  │
│         │                │          │        │                   │                                  │ in net/http                                                  │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2025-22871                   │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────────┴──────────────────────────────────────────────────────────────┘
```

## After

With the latest image, `trivy` shows a CVE that's been published recently that affects `go-runner` however the fix for this is not in the latest image yet.


```
usr/local/bin/go-runner (gobinary)
==================================
Total: 1 (UNKNOWN: 1, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────┬─────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version  │                            Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────┼─────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2025-22871 │ UNKNOWN  │ fixed  │ v1.23.7           │ 1.23.8, 1.24.2 │ Request smuggling due to acceptance of invalid chunked data │
│         │                │          │        │                   │                │ in net/http                                                 │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2025-22871                  │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴────────────────┴─────────────────────────────────────────────────────────────┘
```