### PR TITLE
add flag to paginate list calls

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -102,6 +102,7 @@ func main() {
 	setupLog.Info("Checking args for PE chunk size", "PEChunkSize", controllerCFG.EndpointChunkSize)
 	setupLog.Info("Checking args for policy batch time", "NPBatchTime", controllerCFG.PodUpdateBatchPeriodDuration)
 	setupLog.Info("Checking args for reconciler count", "ReconcilerCount", controllerCFG.MaxConcurrentReconciles)
+	setupLog.Info("Checking args for k8s list call page size", "ListPageSize", controllerCFG.ListPageSize)
 
 	if controllerCFG.EnableConfigMapCheck {
 		var cancelFn context.CancelFunc
@@ -129,7 +130,7 @@ func main() {
 	}
 
 	policyEndpointsManager := policyendpoints.NewPolicyEndpointsManager(mgr.GetClient(),
-		controllerCFG.EndpointChunkSize, ctrl.Log.WithName("endpoints-manager"))
+		controllerCFG.EndpointChunkSize, controllerCFG.ListPageSize, ctrl.Log.WithName("endpoints-manager"))
 	finalizerManager := k8s.NewDefaultFinalizerManager(mgr.GetClient(), ctrl.Log.WithName("finalizer-manager"))
 	policyController := controllers.NewPolicyReconciler(mgr.GetClient(), policyEndpointsManager,
 		controllerCFG, finalizerManager, ctrl.Log.WithName("controllers").WithName("policy"))

--- a/pkg/config/controller_config.go
+++ b/pkg/config/controller_config.go
@@ -12,10 +12,12 @@ const (
 	flagEnableConfigMapCheck         = "enable-configmap-check"
 	flagEndpointChunkSize            = "endpoint-chunk-size"
 	flagEnableGoProfiling            = "enable-goprofiling"
+	flagListPageSize                 = "list-page-size"
 	defaultLogLevel                  = "info"
 	defaultMaxConcurrentReconciles   = 3
 	defaultEndpointsChunkSize        = 200
 	defaultEnableConfigMapCheck      = true
+	defaultListPageSize              = 1000
 	flagPodUpdateBatchPeriodDuration = "pod-update-batch-period-duration"
 	defaultBatchPeriodDuration       = 1 * time.Second
 	defaultEnableGoProfiling         = false
@@ -37,6 +39,8 @@ type ControllerConfig struct {
 	RuntimeConfig RuntimeConfig
 	// EnableGoProfiling enables the goprofiling for dev purpose
 	EnableGoProfiling bool
+	// ListPageSize specifies the page size for k8s list calls
+	ListPageSize int
 }
 
 func (cfg *ControllerConfig) BindFlags(fs *pflag.FlagSet) {
@@ -52,5 +56,7 @@ func (cfg *ControllerConfig) BindFlags(fs *pflag.FlagSet) {
 		"Duration between batch updates of pods")
 	fs.BoolVar(&cfg.EnableGoProfiling, flagEnableGoProfiling, defaultEnableGoProfiling,
 		"Enable goprofiling for develop purpose")
+	fs.IntVar(&cfg.ListPageSize, flagListPageSize, defaultListPageSize,
+		"Page size for k8s list calls")
 	cfg.RuntimeConfig.BindFlags(fs)
 }

--- a/pkg/policyendpoints/manager.go
+++ b/pkg/policyendpoints/manager.go
@@ -29,8 +29,8 @@ type PolicyEndpointsManager interface {
 }
 
 // NewPolicyEndpointsManager constructs a new policyEndpointsManager
-func NewPolicyEndpointsManager(k8sClient client.Client, endpointChunkSize int, logger logr.Logger) *policyEndpointsManager {
-	endpointsResolver := resolvers.NewEndpointsResolver(k8sClient, logger.WithName("endpoints-resolver"))
+func NewPolicyEndpointsManager(k8sClient client.Client, endpointChunkSize int, listPageSize int, logger logr.Logger) *policyEndpointsManager {
+	endpointsResolver := resolvers.NewEndpointsResolver(k8sClient, listPageSize, logger.WithName("endpoints-resolver"))
 	return &policyEndpointsManager{
 		k8sClient:         k8sClient,
 		endpointsResolver: endpointsResolver,

--- a/pkg/resolvers/endpoints_test.go
+++ b/pkg/resolvers/endpoints_test.go
@@ -587,7 +587,7 @@ func TestEndpointsResolver_Resolve(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockClient := mock_client.NewMockClient(ctrl)
-			resolver := NewEndpointsResolver(mockClient, logr.New(&log.NullLogSink{}))
+			resolver := NewEndpointsResolver(mockClient, 1000, logr.New(&log.NullLogSink{}))
 
 			for _, item := range tt.args.podListCalls {
 				call := item
@@ -776,7 +776,7 @@ func TestEndpointsResolver_ResolveNetworkPeers(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockClient := mock_client.NewMockClient(ctrl)
-	resolver := NewEndpointsResolver(mockClient, logr.New(&log.NullLogSink{}))
+	resolver := NewEndpointsResolver(mockClient, 1000, logr.New(&log.NullLogSink{}))
 
 	var ingressEndpoints []policyinfo.EndpointInfo
 	var egressEndpoints []policyinfo.EndpointInfo
@@ -972,7 +972,7 @@ func TestEndpointsResolver_ResolveNetworkPeers_NamedIngressPortsIPBlocks(t *test
 	defer ctrl.Finish()
 
 	mockClient := mock_client.NewMockClient(ctrl)
-	resolver := NewEndpointsResolver(mockClient, logr.New(&log.NullLogSink{}))
+	resolver := NewEndpointsResolver(mockClient, 1000, logr.New(&log.NullLogSink{}))
 
 	var ingressEndpoints []policyinfo.EndpointInfo
 	ctx := context.TODO()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
When the pod scale is large, the current unpaginated list pod call will heavy load apiserver and lead to apiserver timeout.
Add a flag `--list-page-size` to paginate k8s list pod calls, default value is `1000`.

**What does this PR do / Why do we need it**:
Avoid apiserver timeout issue that may lead to controller crash when pod scale is large.

**If an issue # is not available please add steps to reproduce and the controller logs**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!--
List the e2e tests you added as part of this PR.
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new K8s API
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.