### PR TITLE
Add watcher for CRD to restart controller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,12 @@ COPY api/ api/
 COPY pkg/ pkg/
 COPY internal/ internal/
 
+# Copy CRD file for embedding
+COPY charts/amazon-network-policy-controller-k8s/crds/crds.yaml pkg/crd/crds.yaml
+# Short-term workaround for controller-gen version mismatch, should remove once the CRD removed from vpc-cni addon
+RUN sed -i 's/controller-gen.kubebuilder.io\/version: v[0-9]\+\.[0-9]\+\.[0-9]\+/controller-gen.kubebuilder.io\/version: v0.11.3/' pkg/crd/crds.yaml
+
+
 # Version package for passing the ldflags
 # TODO: change this to network controller's version
 ENV VERSION_PKG=github.com/aws/amazon-network-policy-controller-k8s/pkg/version

--- a/Makefile
+++ b/Makefile
@@ -80,9 +80,14 @@ test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
 
 ##@ Build
+.PHONY: prepare-embed
+prepare-embed: ## Prepare files for go:embed.
+	cp charts/amazon-network-policy-controller-k8s/crds/crds.yaml pkg/crd/crds.yaml
+	sed -i 's/controller-gen.kubebuilder.io\/version: v[0-9]\+\.[0-9]\+\.[0-9]\+/controller-gen.kubebuilder.io\/version: v0.11.3/' pkg/crd/crds.yaml
+
 
 .PHONY: build
-build: manifests generate fmt vet ## Build controller binary.
+build: prepare-embed manifests generate fmt vet ## Build controller binary.
 	go build -o bin/controller cmd/main.go
 
 .PHONY: run
@@ -177,13 +182,13 @@ BUILD_IMAGE=public.ecr.aws/docker/library/golang:$(GO_IMAGE_TAG)
 BASE_IMAGE=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:latest.2
 GO_RUNNER_IMAGE=public.ecr.aws/eks-distro/kubernetes/go-runner:v0.18.0-eks-1-32-10
 .PHONY: docker-buildx
-docker-buildx: test
+docker-buildx: prepare-embed test
 	for platform in $(ARCHS); do \
 		docker buildx build --platform=linux/$$platform -t $(IMG)-$$platform --build-arg BASE_IMAGE=$(BASE_IMAGE) --build-arg BUILD_IMAGE=$(BUILD_IMAGE) --build-arg $$platform --load .; \
 	done
 
 .PHONY: docker-buildx-no-test
-docker-buildx-no-test:
+docker-buildx-no-test: prepare-embed
 	for platform in $(ARCHS); do \
                 docker buildx build --platform=linux/$$platform -t $(IMG)_$$platform --build-arg BASE_IMAGE=$(BASE_IMAGE) --build-arg BUILD_IMAGE=$(BUILD_IMAGE) --build-arg $$platform --load .; \
         done

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -50,6 +50,17 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -15,6 +15,15 @@ rules:
   - list
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
   - networking.k8s.aws
   resources:
   - policyendpoints
@@ -50,17 +59,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/pkg/crd/crd_manager.go
+++ b/pkg/crd/crd_manager.go
@@ -1,0 +1,236 @@
+/*
+Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crd
+
+import (
+	"bytes"
+	_ "embed"
+
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
+	"k8s.io/client-go/rest"
+)
+
+//go:embed crds.yaml
+var crdsYAML string
+var desiredCRDs []*v1.CustomResourceDefinition
+
+func init() {
+	var err error
+	desiredCRDs, err = decodeCRDs()
+	if err != nil {
+		panic(fmt.Errorf("failed to decode CRDs from embedded YAML: %w", err))
+	}
+}
+
+// decodeCRDs decodes all CRDs from the embedded YAML file
+func decodeCRDs() ([]*v1.CustomResourceDefinition, error) {
+	decoder := scheme.Codecs.UniversalDeserializer()
+	var crds []*v1.CustomResourceDefinition
+
+	documents := bytes.Split([]byte(crdsYAML), []byte("---"))
+	for _, doc := range documents {
+		if len(bytes.TrimSpace(doc)) == 0 {
+			continue
+		}
+
+		obj := &v1.CustomResourceDefinition{}
+		_, _, err := decoder.Decode(doc, nil, obj)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode CRD from YAML: %w", err)
+		}
+		crds = append(crds, obj)
+	}
+
+	return crds, nil
+}
+
+// CRDManager manages the lifecycle of CRDs
+type CRDManager interface {
+	// Start ensures CRDs exist and starts monitoring them
+	Start(ctx context.Context) error
+}
+
+type defaultCRDManager struct {
+	config   *rest.Config
+	client   apiextclientset.Interface
+	logger   logr.Logger
+	cancelFn context.CancelFunc
+}
+
+// NewCRDManager creates a new CRD manager
+func NewCRDManager(config *rest.Config, logger logr.Logger, cancelFn context.CancelFunc) CRDManager {
+	client, err := apiextclientset.NewForConfig(config)
+	if err != nil {
+		logger.Error(err, "Failed to create apiextensions client")
+		// Return a manager with nil client, it will handle the error in Start()
+	}
+
+	return &defaultCRDManager{
+		config:   config,
+		client:   client,
+		logger:   logger,
+		cancelFn: cancelFn,
+	}
+}
+
+// Start ensures CRDs exist and starts monitoring them
+func (m *defaultCRDManager) Start(ctx context.Context) error {
+	// Check if client was created successfully
+	if m.client == nil {
+		var err error
+		m.client, err = apiextclientset.NewForConfig(m.config)
+		if err != nil {
+			return fmt.Errorf("failed to create apiextensions client: %w", err)
+		}
+	}
+
+	// First ensure all CRDs exist
+	m.logger.Info("Ensuring CRDs exist before starting controller")
+	if err := m.ensureAllCRDs(ctx); err != nil {
+		return fmt.Errorf("failed to ensure CRDs exist: %w", err)
+	}
+
+	// Wait for CRDs to be established
+	if err := m.waitForCRDsEstablished(ctx); err != nil {
+		return fmt.Errorf("failed waiting for CRDs to be established: %w", err)
+	}
+
+	// Start monitoring CRDs
+	go m.monitorCRDs(ctx)
+
+	return nil
+}
+
+// monitorCRDs watches for CRD deletions and triggers controller restart if needed
+func (m *defaultCRDManager) monitorCRDs(ctx context.Context) {
+	ticker := time.NewTicker(15 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			m.logger.Info("CRD manager stopped")
+			return
+		case <-ticker.C:
+			for _, crd := range desiredCRDs {
+				_, err := m.client.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crd.Name, metav1.GetOptions{})
+				if err != nil {
+					if errors.IsNotFound(err) {
+						m.logger.Info("Required CRD not found, triggering controller restart", "name", crd.Name)
+						m.cancelFn() // Trigger controller restart
+						return
+					}
+					m.logger.Error(err, "Error checking CRD", "name", crd.Name)
+				}
+			}
+		}
+	}
+}
+
+// waitForCRDsEstablished waits for all CRDs to be established
+func (m *defaultCRDManager) waitForCRDsEstablished(ctx context.Context) error {
+	m.logger.Info("Waiting for CRDs to be established")
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timeoutCtx.Done():
+			return fmt.Errorf("timeout waiting for CRDs to be established")
+		case <-ticker.C:
+			established := true
+			for _, crd := range desiredCRDs {
+				current, err := m.client.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crd.Name, metav1.GetOptions{})
+				if err != nil {
+					if errors.IsNotFound(err) {
+						established = false
+						break
+					}
+					return err
+				}
+
+				isEstablished := false
+				for _, cond := range current.Status.Conditions {
+					if cond.Type == v1.Established && cond.Status == v1.ConditionTrue {
+						isEstablished = true
+						break
+					}
+				}
+				if !isEstablished {
+					established = false
+					break
+				}
+			}
+			if established {
+				m.logger.Info("All CRDs are established")
+				return nil
+			}
+		}
+	}
+}
+
+// ensureAllCRDs ensures all CRDs exist
+func (m *defaultCRDManager) ensureAllCRDs(ctx context.Context) error {
+	for _, crd := range desiredCRDs {
+		if err := m.ensureCRD(ctx, crd); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ensureCRD ensures the CRD exists
+func (m *defaultCRDManager) ensureCRD(ctx context.Context, crd *v1.CustomResourceDefinition) error {
+	_, err := m.client.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crd.Name, metav1.GetOptions{})
+	if err == nil {
+		m.logger.V(1).Info("CRD already exists", "name", crd.Name)
+		return nil
+	}
+
+	if !errors.IsNotFound(err) {
+		return err
+	}
+
+	m.logger.Info("CRD doesn't exist, creating it", "name", crd.Name)
+	_, err = m.client.ApiextensionsV1().CustomResourceDefinitions().Create(ctx, crd, metav1.CreateOptions{})
+	if err == nil {
+		m.logger.Info("Successfully created CRD", "name", crd.Name)
+		return nil
+	}
+
+	if errors.IsAlreadyExists(err) || errors.IsConflict(err) {
+		m.logger.V(1).Info("CRD already exists or conflict", "name", crd.Name)
+		return nil
+	}
+
+	m.logger.Error(err, "Failed to create CRD", "name", crd.Name)
+	return err
+}

--- a/pkg/crd/crd_test.go
+++ b/pkg/crd/crd_test.go
@@ -1,0 +1,320 @@
+/*
+Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crd
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func Test_decodeCRDs(t *testing.T) {
+	g := NewWithT(t)
+
+	// Test that CRDs are decoded correctly
+	crds, err := decodeCRDs()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(crds).ToNot(BeEmpty())
+
+	// Verify the first CRD has expected properties
+	g.Expect(crds[0].Spec.Group).To(Equal("networking.k8s.aws"))
+	g.Expect(crds[0].Spec.Names.Kind).To(Equal("PolicyEndpoint"))
+}
+
+func Test_ensureCRD(t *testing.T) {
+	g := NewWithT(t)
+
+	// Create a fake client
+	client := apiextfake.NewSimpleClientset()
+
+	// Create a test CRD
+	testCRD := &v1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test.example.com",
+		},
+		Spec: v1.CustomResourceDefinitionSpec{
+			Group: "example.com",
+			Names: v1.CustomResourceDefinitionNames{
+				Kind: "Test",
+			},
+			Scope: v1.NamespaceScoped,
+			Versions: []v1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1",
+					Served:  true,
+					Storage: true,
+					Schema: &v1.CustomResourceValidation{
+						OpenAPIV3Schema: &v1.JSONSchemaProps{
+							Type: "object",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Create a CRD manager
+	manager := &defaultCRDManager{
+		client: client,
+		logger: logr.Discard(),
+	}
+
+	// Test creating a CRD
+	err := manager.ensureCRD(context.Background(), testCRD)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Verify the CRD was created
+	crd, err := client.ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), testCRD.Name, metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(crd.Name).To(Equal(testCRD.Name))
+
+	// Test creating the same CRD again (should be a no-op)
+	err = manager.ensureCRD(context.Background(), testCRD)
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func Test_ensureCRD_AlreadyExists(t *testing.T) {
+	g := NewWithT(t)
+
+	// Create a fake client with a reactor that returns AlreadyExists error
+	client := apiextfake.NewSimpleClientset()
+	client.PrependReactor("create", "customresourcedefinitions", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.NewAlreadyExists(
+			schema.GroupResource{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"},
+			"test.example.com")
+	})
+
+	// Create a test CRD
+	testCRD := &v1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test.example.com",
+		},
+	}
+
+	// Create a CRD manager
+	manager := &defaultCRDManager{
+		client: client,
+		logger: logr.Discard(),
+	}
+
+	// Test creating a CRD that already exists
+	err := manager.ensureCRD(context.Background(), testCRD)
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func Test_ensureCRD_Conflict(t *testing.T) {
+	g := NewWithT(t)
+
+	// Create a fake client with a reactor that returns Conflict error
+	client := apiextfake.NewSimpleClientset()
+	client.PrependReactor("create", "customresourcedefinitions", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.NewConflict(
+			schema.GroupResource{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"},
+			"test.example.com", nil)
+	})
+
+	// Create a test CRD
+	testCRD := &v1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test.example.com",
+		},
+	}
+
+	// Create a CRD manager
+	manager := &defaultCRDManager{
+		client: client,
+		logger: logr.Discard(),
+	}
+
+	// Test creating a CRD with conflict
+	err := manager.ensureCRD(context.Background(), testCRD)
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func Test_ensureCRD_OtherError(t *testing.T) {
+	g := NewWithT(t)
+
+	// Create a fake client with a reactor that returns Forbidden error
+	client := apiextfake.NewSimpleClientset()
+	client.PrependReactor("create", "customresourcedefinitions", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.NewForbidden(
+			schema.GroupResource{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"},
+			"test.example.com", nil)
+	})
+
+	// Create a test CRD
+	testCRD := &v1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test.example.com",
+		},
+	}
+
+	// Create a CRD manager
+	manager := &defaultCRDManager{
+		client: client,
+		logger: logr.Discard(),
+	}
+
+	// Test creating a CRD with other error
+	err := manager.ensureCRD(context.Background(), testCRD)
+	g.Expect(err).To(HaveOccurred())
+}
+
+func Test_monitorCRDs(t *testing.T) {
+	g := NewWithT(t)
+
+	// Create a test CRD
+	testCRD := &v1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test.example.com",
+		},
+	}
+
+	// Create a fake client with the CRD
+	client := apiextfake.NewSimpleClientset(testCRD)
+
+	// Create a context with cancel
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Track if cancel was called
+	cancelCalled := false
+	cancelFn := func() {
+		cancelCalled = true
+		cancel()
+	}
+
+	// Create a CRD manager
+	manager := &defaultCRDManager{
+		client:   client,
+		logger:   logr.Discard(),
+		cancelFn: cancelFn,
+		config:   &rest.Config{},
+	}
+
+	// Override desiredCRDs for this test
+	originalCRDs := desiredCRDs
+	desiredCRDs = []*v1.CustomResourceDefinition{testCRD}
+	defer func() { desiredCRDs = originalCRDs }()
+
+	// Start monitoring in a goroutine with a short interval for testing
+	go manager.monitorCRDsWithInterval(ctx, 10*time.Millisecond)
+
+	// Wait a bit to ensure monitoring has started
+	time.Sleep(50 * time.Millisecond)
+
+	// Delete the CRD
+	err := client.ApiextensionsV1().CustomResourceDefinitions().Delete(ctx, testCRD.Name, metav1.DeleteOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Verify cancel was called with a longer timeout
+	g.Eventually(func() bool {
+		return cancelCalled
+	}, 2*time.Second, 50*time.Millisecond).Should(BeTrue())
+}
+
+func Test_NewCRDManager(t *testing.T) {
+	g := NewWithT(t)
+
+	// Create a CRD manager
+	cancelFn := func() {}
+	manager := NewCRDManager(&rest.Config{}, logr.Discard(), cancelFn)
+
+	// Verify the manager was created
+	g.Expect(manager).ToNot(BeNil())
+}
+
+func Test_waitForCRDsEstablished(t *testing.T) {
+	g := NewWithT(t)
+
+	// Create a test CRD with Established condition
+	testCRD := &v1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test.example.com",
+		},
+		Status: v1.CustomResourceDefinitionStatus{
+			Conditions: []v1.CustomResourceDefinitionCondition{
+				{
+					Type:   v1.Established,
+					Status: v1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	// Create a fake client with the CRD
+	client := apiextfake.NewSimpleClientset(testCRD)
+
+	// Create a CRD manager
+	manager := &defaultCRDManager{
+		client: client,
+		logger: logr.Discard(),
+	}
+
+	// Override desiredCRDs for this test
+	originalCRDs := desiredCRDs
+	desiredCRDs = []*v1.CustomResourceDefinition{testCRD}
+	defer func() { desiredCRDs = originalCRDs }()
+
+	// Test waiting for CRDs to be established
+	err := manager.waitForCRDsEstablished(context.Background())
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func Test_waitForCRDsEstablished_NotEstablished(t *testing.T) {
+	g := NewWithT(t)
+
+	// Create a test CRD without Established condition
+	testCRD := &v1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test.example.com",
+		},
+	}
+
+	// Create a fake client with the CRD
+	client := apiextfake.NewSimpleClientset(testCRD)
+
+	// Create a CRD manager
+	manager := &defaultCRDManager{
+		client: client,
+		logger: logr.Discard(),
+	}
+
+	// Override desiredCRDs for this test
+	originalCRDs := desiredCRDs
+	desiredCRDs = []*v1.CustomResourceDefinition{testCRD}
+	defer func() { desiredCRDs = originalCRDs }()
+
+	// Create a context with short timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	// Test waiting for CRDs to be established (should timeout)
+	err := manager.waitForCRDsEstablished(ctx)
+	g.Expect(err).To(HaveOccurred())
+}

--- a/pkg/crd/crds.yaml
+++ b/pkg/crd/crds.yaml
@@ -1,0 +1,234 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: amazon-network-policy-controller-k8s
+  name: policyendpoints.networking.k8s.aws
+spec:
+  group: networking.k8s.aws
+  names:
+    kind: PolicyEndpoint
+    listKind: PolicyEndpointList
+    plural: policyendpoints
+    singular: policyendpoint
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PolicyEndpoint is the Schema for the policyendpoints API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PolicyEndpointSpec defines the desired state of PolicyEndpoint
+            properties:
+              egress:
+                description: Egress is the list of egress rules containing resolved
+                  network addresses
+                items:
+                  description: EndpointInfo defines the network endpoint information
+                    for the policy ingress/egress
+                  properties:
+                    cidr:
+                      description: CIDR is the network address(s) of the endpoint
+                      type: string
+                    except:
+                      description: Except is the exceptions to the CIDR ranges mentioned
+                        above.
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: Ports is the list of ports
+                      items:
+                        description: Port contains information about the transport
+                          port/protocol
+                        properties:
+                          endPort:
+                            description: Endport specifies the port range port to
+                              endPort port must be defined and an integer, endPort
+                              > port
+                            format: int32
+                            type: integer
+                          port:
+                            description: Port specifies the numerical port for the
+                              protocol. If empty applies to all ports
+                            format: int32
+                            type: integer
+                          protocol:
+                            default: TCP
+                            description: Protocol specifies the transport protocol,
+                              default TCP
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - cidr
+                  type: object
+                type: array
+              ingress:
+                description: Ingress is the list of ingress rules containing resolved
+                  network addresses
+                items:
+                  description: EndpointInfo defines the network endpoint information
+                    for the policy ingress/egress
+                  properties:
+                    cidr:
+                      description: CIDR is the network address(s) of the endpoint
+                      type: string
+                    except:
+                      description: Except is the exceptions to the CIDR ranges mentioned
+                        above.
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: Ports is the list of ports
+                      items:
+                        description: Port contains information about the transport
+                          port/protocol
+                        properties:
+                          endPort:
+                            description: Endport specifies the port range port to
+                              endPort port must be defined and an integer, endPort
+                              > port
+                            format: int32
+                            type: integer
+                          port:
+                            description: Port specifies the numerical port for the
+                              protocol. If empty applies to all ports
+                            format: int32
+                            type: integer
+                          protocol:
+                            default: TCP
+                            description: Protocol specifies the transport protocol,
+                              default TCP
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - cidr
+                  type: object
+                type: array
+              podIsolation:
+                description: PodIsolation specifies whether the pod needs to be isolated
+                  for a particular traffic direction Ingress or Egress, or both. If
+                  default isolation is not specified, and there are no ingress/egress
+                  rules, then the pod is not isolated from the point of view of this
+                  policy. This follows the NetworkPolicy spec.PolicyTypes.
+                items:
+                  description: PolicyType string describes the NetworkPolicy type
+                    This type is beta-level in 1.8
+                  type: string
+                type: array
+              podSelector:
+                description: PodSelector is the podSelector from the policy resource
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              podSelectorEndpoints:
+                description: PodSelectorEndpoints contains information about the pods
+                  matching the podSelector
+                items:
+                  description: PodEndpoint defines the summary information for the
+                    pods
+                  properties:
+                    hostIP:
+                      description: HostIP is the IP address of the host the pod is
+                        currently running on
+                      type: string
+                    name:
+                      description: Name is the pod name
+                      type: string
+                    namespace:
+                      description: Namespace is the pod namespace
+                      type: string
+                    podIP:
+                      description: PodIP is the IP address of the pod
+                      type: string
+                  required:
+                  - hostIP
+                  - name
+                  - namespace
+                  - podIP
+                  type: object
+                type: array
+              policyRef:
+                description: PolicyRef is a reference to the Kubernetes NetworkPolicy
+                  resource.
+                properties:
+                  name:
+                    description: Name is the name of the Policy
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Policy
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+            required:
+            - policyRef
+            type: object
+          status:
+            description: PolicyEndpointStatus defines the observed state of PolicyEndpoint
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/pkg/crd/crds.yaml
+++ b/pkg/crd/crds.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: amazon-network-policy-controller-k8s


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
-->
**What type of PR is this?**
feature

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
Currently the PolicyEndpoint CRD is part of vpc-cni addon, the addon got removed the CRD will be uninstalled.

Add the crd manager to ensure this CRD be always available

**If an issue # is not available please add steps to reproduce and the controller logs**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

Scenario 1
- Create cluster with VPC-CNI addon -> PolicyEnpoint CRD installed originally
```
k get crds  | grep policy
policyendpoints.networking.k8s.aws           2025-06-18T20:43:14Z
```
- Manual remove CRD
```
k delete crd policyendpoints.networking.k8s.aws
customresourcedefinition.apiextensions.k8s.io "policyendpoints.networking.k8s.aws" deleted
```
- The crd manager restart the controller and recreate it 
```
{"level":"info","ts":"2025-06-18T20:51:28Z","logger":"setup.crd-manager","msg":"CRD doesn't exist, creating it","name":"policyendpoints.networking.k8s.aws"}
```
```
k get crds  | grep policy
policyendpoints.networking.k8s.aws           2025-06-18T20:51:28Z
```

Scenario 2
- Remove vpc-cni via delete-addon call
```
beks delete-addon --cluster-name npc-crd --addon-name vpc-cni
{
    "addon": {
        "addonName": "vpc-cni",
        "clusterName": "npc-crd",
        "status": "DELETING",
        "addonVersion": "v1.19.5-eksbuild.1",
        "health": {
            "issues": []
        },
        "addonArn": "arn:aws:eks:us-west-2:xxx:addon/npc-crd/vpc-cni/44cbc260-bad5-3893-6384-099d7d725bc0",
        "createdAt": "2025-06-18T13:36:02.120000-07:00",
        "modifiedAt": "2025-06-18T13:53:52.015000-07:00",
        "tags": {}
    }
}
```
- crd still represent
```
k get crds  | grep policy
policyendpoints.networking.k8s.aws           2025-06-18T20:51:28Z
```

Scenario 3
- Reinstall vpc-cni via create-addon call (with the short-term fix for the annotation mismatch)
```
beks describe-addon --cluster-name npc-crd --addon-name vpc-cni
{
    "addon": {
        "addonName": "vpc-cni",
        "clusterName": "npc-crd",
        "status": "ACTIVE",
        "addonVersion": "v1.19.5-eksbuild.1",
        "health": {
            "issues": []
        },
        "addonArn": "arn:aws:eks:us-west-2:171391670848:addon/npc-crd/vpc-cni/58cbc26a-43db-5d07-d5f3-2b723ce148db",
        "createdAt": "2025-06-18T13:56:50.544000-07:00",
        "modifiedAt": "2025-06-18T13:57:29.607000-07:00",
        "tags": {}
    }
}
```
it pass and do not recreate the crd
```
k get crds  | grep policy
policyendpoints.networking.k8s.aws           2025-06-18T20:51:28Z
```

**Automation added to e2e**:
<!--
List the e2e tests you added as part of this PR.
If no, create an issue with enhancement/testing label
-->
see `crd_manager_test.go`

**Will this PR introduce any new dependencies?**:
<!--
e.g. new K8s API
-->
N/A

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
should not break upgrades or downgrades.

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.