### PR TITLE
Update go-runner to point to latest image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,18 @@
 ARG BASE_IMAGE
 ARG BUILD_IMAGE
+ARG GORUNNER_IMAGE
 ARG ARCH=amd64
+
 # Build the controller binary
-FROM $BUILD_IMAGE as builder
+FROM ${BUILD_IMAGE} AS builder
 
 WORKDIR /workspace
-ENV GOPROXY direct
+ENV GOPROXY=direct
 
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
+
 RUN go mod download
 
 # Copy the go source
@@ -21,21 +22,24 @@ COPY api/ api/
 COPY pkg/ pkg/
 COPY internal/ internal/
 
-# Version package for passing the ldflags
-# TODO: change this to network controller's version
 ENV VERSION_PKG=github.com/aws/amazon-network-policy-controller-k8s/pkg/version
-# Build
-RUN GIT_VERSION=$(git describe --tags --always) && \
-        GIT_COMMIT=$(git rev-parse HEAD) && \
-        BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z) && \
-        CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} GO111MODULE=on go build \
-        -ldflags="-X ${VERSION_PKG}.GitVersion=${GIT_VERSION} -X ${VERSION_PKG}.GitCommit=${GIT_COMMIT} -X ${VERSION_PKG}.BuildDate=${BUILD_DATE}" -a -o controller cmd/main.go
 
-FROM $BASE_IMAGE
+RUN GIT_VERSION=$(git describe --tags --always) && \
+    GIT_COMMIT=$(git rev-parse HEAD) && \
+    BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z) && \
+    CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} GO111MODULE=on go build \
+    -ldflags="-X ${VERSION_PKG}.GitVersion=${GIT_VERSION} -X ${VERSION_PKG}.GitCommit=${GIT_COMMIT} -X ${VERSION_PKG}.BuildDate=${BUILD_DATE}" \
+    -a -o controller cmd/main.go
+
+FROM ${GORUNNER_IMAGE} AS go-runner
+
+# Final image
+FROM ${BASE_IMAGE}
 
 WORKDIR /
-COPY --from=public.ecr.aws/eks-distro/kubernetes/go-runner:v0.18.0-eks-1-32-11 /go-runner /usr/local/bin/go-runner
+COPY --from=go-runner /go-runner /usr/local/bin/go-runner
 COPY --from=builder /workspace/controller .
+
 USER 65532:65532
 
 ENTRYPOINT ["/controller"]

--- a/Makefile
+++ b/Makefile
@@ -173,20 +173,20 @@ $(MOCKGEN): $(LOCALBIN)
 	test -s $(MOCKGEN) || GOBIN=$(LOCALBIN) go install github.com/golang/mock/mockgen@v1.6.0
 
 GO_IMAGE_TAG=$(shell cat .go-version)
-BUILD_IMAGE=public.ecr.aws/docker/library/golang:$(GO_IMAGE_TAG)
-BASE_IMAGE=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:latest.2
-GO_RUNNER_IMAGE=public.ecr.aws/eks-distro/kubernetes/go-runner:v0.18.0-eks-1-32-10
+BUILD_IMAGE ?= public.ecr.aws/docker/library/golang:$(GO_IMAGE_TAG)
+BASE_IMAGE ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:latest.2
+GO_RUNNER_IMAGE ?= public.ecr.aws/eks-distro/kubernetes/go-runner:v0.18.0-eks-1-32-latest
 .PHONY: docker-buildx
 docker-buildx: test
 	for platform in $(ARCHS); do \
-		docker buildx build --platform=linux/$$platform -t $(IMG)-$$platform --build-arg BASE_IMAGE=$(BASE_IMAGE) --build-arg BUILD_IMAGE=$(BUILD_IMAGE) --build-arg $$platform --load .; \
+		docker buildx build --platform=linux/$$platform -t $(IMG)-$$platform --build-arg BASE_IMAGE=$(BASE_IMAGE) --build-arg BUILD_IMAGE=$(BUILD_IMAGE) --build-arg GORUNNER_IMAGE=$(GO_RUNNER_IMAGE) --build-arg $$platform --load .; \
 	done
 
 .PHONY: docker-buildx-no-test
 docker-buildx-no-test:
 	for platform in $(ARCHS); do \
-                docker buildx build --platform=linux/$$platform -t $(IMG)_$$platform --build-arg BASE_IMAGE=$(BASE_IMAGE) --build-arg BUILD_IMAGE=$(BUILD_IMAGE) --build-arg $$platform --load .; \
-        done
+        docker buildx build --platform=linux/$$platform -t $(IMG)_$$platform --build-arg BASE_IMAGE=$(BASE_IMAGE) --build-arg BUILD_IMAGE=$(BUILD_IMAGE) --build-arg GORUNNER_IMAGE=$(GO_RUNNER_IMAGE) --build-arg $$platform --load .; \
+    done
 
 # Check formatting of source code files without modification.
 check-format: FORMAT_FLAGS = -l

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/aws/amazon-network-policy-controller-k8s
 
 go 1.23.0
 
-toolchain go1.23.6
+toolchain go1.23.10
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
-->
**What type of PR is this?**
dependency update

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**: CVE fixes in go-runner


**What does this PR do / Why do we need it**:
This updatest the tag name from a `v0.18.0-eks-1-32-latest` instead of `v0.18.0-eks-1.32-XX`. Pinning causes issues where CVEs cannot be patched when a new image is available


**If an issue # is not available please add steps to reproduce and the controller logs**: N/A


**Testing done on this change**: N/A
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:  N/A
<!--
List the e2e tests you added as part of this PR.
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:  N/A
<!--
e.g. new K8s API
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
 N/A

**Does this PR introduce any user-facing change?**:  N/A
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.