### PR TITLE
Fix issue where PolicyEndpoints are not updated correctly when Pods a…

### DIFF
--- a/internal/eventhandlers/pod.go
+++ b/internal/eventhandlers/pod.go
@@ -65,7 +65,8 @@ func (h *enqueueRequestForPodEvent) Update(ctx context.Context, e event.UpdateEv
 	if equality.Semantic.DeepEqual(podOld.Annotations, podNew.Annotations) &&
 		equality.Semantic.DeepEqual(podOld.Labels, podNew.Labels) &&
 		equality.Semantic.DeepEqual(podOld.DeletionTimestamp.IsZero(), podNew.DeletionTimestamp.IsZero()) &&
-		equality.Semantic.DeepEqual(podOld.Status.PodIP, podNew.Status.PodIP) {
+		equality.Semantic.DeepEqual(podOld.Status.PodIP, podNew.Status.PodIP) &&
+		equality.Semantic.DeepEqual(podOld.Status.Phase, podNew.Status.Phase) {
 		return
 	}
 	h.enqueueReferredPolicies(ctx, q, podNew, podOld)

--- a/pkg/k8s/pod_utils.go
+++ b/pkg/k8s/pod_utils.go
@@ -20,6 +20,13 @@ func GetPodIP(pod *corev1.Pod) string {
 	}
 }
 
+// IsPodNetworkReady returns true if the pod has at least 1 IP address and is in a running state
+func IsPodNetworkReady(pod *corev1.Pod) bool {
+	return len(GetPodIP(pod)) > 0 &&
+		pod.Status.Phase != corev1.PodSucceeded &&
+		pod.Status.Phase != corev1.PodFailed
+}
+
 // LookupContainerPortAndName returns numerical containerPort and portName for specific port and protocol
 func LookupContainerPortAndName(pod *corev1.Pod, port intstr.IntOrString, protocol corev1.Protocol) (int32, string, error) {
 	for _, podContainer := range pod.Spec.Containers {

--- a/pkg/k8s/pod_utils_test.go
+++ b/pkg/k8s/pod_utils_test.go
@@ -185,3 +185,57 @@ func Test_LookupContainerPortAndName(t *testing.T) {
 		})
 	}
 }
+func TestIsPodNetworkReady(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      *corev1.Pod
+		expected bool
+	}{
+		{
+			name: "running pod with IP",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					PodIP: "10.0.0.1",
+					Phase: corev1.PodRunning,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "succeeded pod with IP should be excluded",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					PodIP: "10.0.0.1",
+					Phase: corev1.PodSucceeded,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "failed pod with IP should be excluded",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					PodIP: "10.0.0.1",
+					Phase: corev1.PodFailed,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "running pod without IP",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsPodNetworkReady(tt.pod)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
Fix issue where PolicyEndpoints are not updated correctly when Pods are in a terminal phase (Succeeded or Failed).

**What type of PR is this?**
Bug Fix.

**Which issue does this PR fix**: IP Addresses can be re-assigned after a Pod has reached a terminal phase (Succeeded or Failed) but the Policy Endpoint will not be updated correctly until the Pod is deleted.


**What does this PR do / Why do we need it**: Enforcement is not working correctly for Pods in the Terminal Phase since their IP Addresses have been re-assigned but the Controller has not processed their completion.


**If an issue # is not available please add steps to reproduce and the controller logs**:

**Testing done on this change**:
Added new tests. Confirmed test failed before making change.

BEFORE:

```
?   	github.com/aws/amazon-network-policy-controller-k8s/api/v1alpha1	[no test files]
?   	github.com/aws/amazon-network-policy-controller-k8s/cmd	[no test files]
ok  	github.com/aws/amazon-network-policy-controller-k8s/internal/controllers	(cached)
?   	github.com/aws/amazon-network-policy-controller-k8s/internal/eventhandlers	[no test files]
?   	github.com/aws/amazon-network-policy-controller-k8s/mocks/controller-runtime/client	[no test files]
ok  	github.com/aws/amazon-network-policy-controller-k8s/pkg/config	(cached)
ok  	github.com/aws/amazon-network-policy-controller-k8s/pkg/crd	(cached)
ok  	github.com/aws/amazon-network-policy-controller-k8s/pkg/k8s	0.591s
ok  	github.com/aws/amazon-network-policy-controller-k8s/pkg/policyendpoints	(cached)
--- FAIL: TestEndpointsResolver_ExcludesTerminalPods (0.00s)
    endpoints_test.go:1175:
        	Error Trace:	/Users/carlhilt/work/eks/networking/network-policy/amazon-network-policy-controller-k8s/pkg/resolvers/endpoints_test.go:1175
        	Error:      	"[{ 10.0.0.1 running-pod test-ns} { 10.0.0.2 succeeded-pod test-ns} { 10.0.0.3 failed-pod test-ns}]" should have 1 item(s), but has 3
        	Test:       	TestEndpointsResolver_ExcludesTerminalPods
        	Messages:   	Should only include running pod in PolicyEndpoints
FAIL
FAIL	github.com/aws/amazon-network-policy-controller-k8s/pkg/resolvers	0.572s
?   	github.com/aws/amazon-network-policy-controller-k8s/pkg/utils/configmap	[no test files]
?   	github.com/aws/amazon-network-policy-controller-k8s/pkg/version	[no test files]
FAIL
```

AFTER:

```?   	github.com/aws/amazon-network-policy-controller-k8s/api/v1alpha1	[no test files]
?   	github.com/aws/amazon-network-policy-controller-k8s/cmd	[no test files]
ok  	github.com/aws/amazon-network-policy-controller-k8s/internal/controllers	(cached)
?   	github.com/aws/amazon-network-policy-controller-k8s/internal/eventhandlers	[no test files]
?   	github.com/aws/amazon-network-policy-controller-k8s/mocks/controller-runtime/client	[no test files]
ok  	github.com/aws/amazon-network-policy-controller-k8s/pkg/config	(cached)
ok  	github.com/aws/amazon-network-policy-controller-k8s/pkg/crd	(cached)
ok  	github.com/aws/amazon-network-policy-controller-k8s/pkg/k8s	(cached)
ok  	github.com/aws/amazon-network-policy-controller-k8s/pkg/policyendpoints	(cached)
ok  	github.com/aws/amazon-network-policy-controller-k8s/pkg/resolvers	(cached)
?   	github.com/aws/amazon-network-policy-controller-k8s/pkg/utils/configmap	[no test files]
?   	github.com/aws/amazon-network-policy-controller-k8s/pkg/version	[no test files]```
```

**Automation added to e2e**: N/A

**Will this PR introduce any new dependencies?**: No.

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**: No. N/A.

**Does this PR introduce any user-facing change?**: No, just a bug fix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.