### PR TITLE
Preserve Pod Phase when stripping down object for IsPodNetworkReady to work correctly

### DIFF
--- a/pkg/k8s/pod_utils.go
+++ b/pkg/k8s/pod_utils.go
@@ -90,6 +90,7 @@ func stripDownPodObject(pod *corev1.Pod) *corev1.Pod {
 		HostIPs: pod.Status.HostIPs,
 		PodIP:   pod.Status.PodIP,
 		PodIPs:  pod.Status.PodIPs,
+		Phase:   pod.Status.Phase,
 	}
 	return pod
 }


### PR DESCRIPTION
We made changes in #190 to rely on the Phase of a Pod to decide if it should be included in the PolicyEndpoints. However, we were not preserving the Pod Phase when stripping it down, causing all Pods to still continue to be included. This correctly preserves the Pod IP for that behavior to work.

\**What type of PR is this?** Bug Fix.

**Which issue does this PR fix**: N/A.


**What does this PR do / Why do we need it**: Correctly preserves the Phase of a Pod so that Succeeded or Failed pods are correctly filtered out of `PolicyEndpoints`.


**If an issue # is not available please add steps to reproduce and the controller logs**:

```
{"level":"info","ts":"2025-09-18T06:57:58Z","logger":"endpoints-manager.endpoints-resolver","msg":"DEBUG_FIX: Checking pod","name":"test-allowed-7qz9k","phase":"Succeeded","ready":false}
{"level":"info","ts":"2025-09-18T06:57:58Z","logger":"endpoints-manager.endpoints-resolver","msg":"DEBUG_FIX: Full pod object","pod":{"kind":"Pod","apiVersion":"v1","metadata":{"name":"test-allowed-7qz9k","namespace":"networkpolicy-test","uid":"3b768934-0dc5-45c4-845d-e8aefdd31053","resourceVersion":"21090","creationTimestamp":null,"labels":{"batch.kubernetes.io/controller-uid":"4bc00415-05b0-4687-8e68-4cde6d2e6460","batch.kubernetes.io/job-name":"test-allowed","controller-uid":"4bc00415-05b0-4687-8e68-4cde6d2e6460","force-reconcile":"true","job-name":"test-allowed","test":"allowed","test-fix":"true"}},"spec":{"containers":[{"name":"curl","resources":{}}]},"status":{"phase":"Succeeded","hostIP":"10.4.1.2","hostIPs":[{"ip":"10.4.1.2"}],"podIP":"10.244.0.13","podIPs":[{"ip":"10.244.0.13"}]}}}
{"level":"info","ts":"2025-09-18T06:57:58Z","logger":"endpoints-manager.endpoints-resolver","msg":"DEBUG_FIX: MADE IT, Excluding pod","name":"test-allowed-7qz9k","phase":"Succeeded"}
{"level":"info","ts":"2025-09-18T06:57:58Z","logger":"endpoints-manager.endpoints-resolver","msg":"Resolved endpoints","policy":{"name":"ingress","namespace":"networkpolicy-test"},"ingress":0,"egress":0,"pod selector endpoints":1}
{"level":"info","ts":"2025-09-18T06:57:58Z","logger":"endpoints-manager","msg":"Got policy endpoints lists","create":0,"update":1,"delete":0}
```


**Testing done on this change**:
SETUP:
```
> kubectl get pods -A -o custom-columns=NAME:.metadata.name,IP:.status.podIP,STATUS:.status.phase
NAME                                                    IP            STATUS
amazon-network-policy-controller-k8s-6949d98c9b-k8pvn   10.244.0.25   Running
coredns-66bc5c9577-2l987                                10.244.0.4    Running
coredns-66bc5c9577-vqp2g                                10.244.0.3    Running
etcd-npc-test-control-plane                             10.4.1.2      Running
kindnet-92h59                                           10.4.1.2      Running
kube-apiserver-npc-test-control-plane                   10.4.1.2      Running
kube-controller-manager-npc-test-control-plane          10.4.1.2      Running
kube-proxy-jmxnw                                        10.4.1.2      Running
kube-scheduler-npc-test-control-plane                   10.4.1.2      Running
local-path-provisioner-7b8c8ddbd6-58c67                 10.244.0.2    Running
test-allowed-7qz9k                                      10.244.0.13   Succeeded
test-blocked-42zwl                                      10.244.0.17   Failed
test-blocked-hnmkp                                      10.244.0.18   Failed
test-blocked-kr2qj                                      10.244.0.15   Failed
test-blocked-q22g7                                      10.244.0.14   Failed
test-blocked-qlpwn                                      10.244.0.16   Failed
test-blocked-tmjhx                                      10.244.0.19   Failed
test-blocked-vvvdw                                      10.244.0.20   Failed
test-fix-allowed-klxjx                                  10.244.0.23   Succeeded
whoami-7c7f4944c6-9trkf                                 10.244.0.12   Running
```

```
Name:         ingress
Namespace:    networkpolicy-test
Created on:   2025-09-17 21:43:07 -0700 PDT
Labels:       <none>
Annotations:  <none>
Spec:
  PodSelector:     <none> (Allowing the specific traffic to all pods in this namespace)
  Allowing ingress traffic:
    To Port: 80/TCP
    From:
      PodSelector: test=allowed
  Not affecting egress traffic
  Policy Types: Ingress
```

BEFORE:

```
Name:         ingress-8rbdk
Namespace:    networkpolicy-test
Labels:       <none>
Annotations:  <none>
API Version:  networking.k8s.aws/v1alpha1
Kind:         PolicyEndpoint
Metadata:
  Creation Timestamp:  2025-09-18T04:43:07Z
  Generate Name:       ingress-
  Generation:          1
  Owner References:
    API Version:           networking.k8s.io/v1
    Block Owner Deletion:  true
    Controller:            true
    Kind:                  NetworkPolicy
    Name:                  ingress
    UID:                   ae4fd2c9-6d77-4115-9013-4559b27b3b6c
  Resource Version:        16149
  UID:                     c7dc22db-baac-486f-ab27-9038b03d4cee
Spec:
  Ingress:
    Cidr:  10.244.0.13
    Ports:
      Port:      80
      Protocol:  TCP
    Cidr:        10.244.0.23
    Ports:
      Port:      80
      Protocol:  TCP
  Pod Isolation:
    Ingress
  Pod Selector:
  Pod Selector Endpoints:
    Host IP:    10.4.1.2
    Name:       test-blocked-qlpwn
    Namespace:  networkpolicy-test
    Pod IP:     10.244.0.16
    Host IP:    10.4.1.2
    Name:       test-blocked-tmjhx
    Namespace:  networkpolicy-test
    Pod IP:     10.244.0.19
    Host IP:    10.4.1.2
    Name:       test-blocked-vvvdw
    Namespace:  networkpolicy-test
    Pod IP:     10.244.0.20
    Host IP:    10.4.1.2
    Name:       test-allowed-7qz9k
    Namespace:  networkpolicy-test
    Pod IP:     10.244.0.13
    Host IP:    10.4.1.2
    Name:       test-blocked-42zwl
    Namespace:  networkpolicy-test
    Pod IP:     10.244.0.17
    Host IP:    10.4.1.2
    Name:       test-blocked-hnmkp
    Namespace:  networkpolicy-test
    Pod IP:     10.244.0.18
    Host IP:    10.4.1.2
    Name:       test-blocked-kr2qj
    Namespace:  networkpolicy-test
    Pod IP:     10.244.0.15
    Host IP:    10.4.1.2
    Name:       test-blocked-q22g7
    Namespace:  networkpolicy-test
    Pod IP:     10.244.0.14
    Host IP:    10.4.1.2
    Name:       test-fix-allowed-klxjx
    Namespace:  networkpolicy-test
    Pod IP:     10.244.0.23
    Host IP:    10.4.1.2
    Name:       whoami-7c7f4944c6-9trkf
    Namespace:  networkpolicy-test
    Pod IP:     10.244.0.12
  Policy Ref:
    Name:       ingress
    Namespace:  networkpolicy-test
Events:         <none>
```

AFTER

```
Name:         ingress-8rbdk
Namespace:    networkpolicy-test
Labels:       <none>
Annotations:  <none>
API Version:  networking.k8s.aws/v1alpha1
Kind:         PolicyEndpoint
Metadata:
  Creation Timestamp:  2025-09-18T04:43:07Z
  Generate Name:       ingress-
  Generation:          2
  Owner References:
    API Version:           networking.k8s.io/v1
    Block Owner Deletion:  true
    Controller:            true
    Kind:                  NetworkPolicy
    Name:                  ingress
    UID:                   ae4fd2c9-6d77-4115-9013-4559b27b3b6c
  Resource Version:        30026
  UID:                     c7dc22db-baac-486f-ab27-9038b03d4cee
Spec:
  Pod Isolation:
    Ingress
  Pod Selector:
  Pod Selector Endpoints:
    Host IP:    10.4.1.2
    Name:       whoami-7c7f4944c6-9trkf
    Namespace:  networkpolicy-test
    Pod IP:     10.244.0.12
  Policy Ref:
    Name:       ingress
    Namespace:  networkpolicy-test
Events:         <none>
```

**Automation added to e2e**: N/A

**Will this PR introduce any new dependencies?**: No.

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**: No. N/A.


**Does this PR introduce any user-facing change?**: No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.