### PR TITLE
trim logs

### DIFF
--- a/pkg/resolvers/endpoints.go
+++ b/pkg/resolvers/endpoints.go
@@ -233,7 +233,7 @@ func (r *defaultEndpointsResolver) getIngressRulesPorts(ctx context.Context, pol
 
 	// since we pull ports from dst pods, we should deduplicate them
 	dedupedPorts := dedupPorts(portList)
-	r.logger.Info("Got ingress ports from dst pods", "port", dedupedPorts)
+	r.logger.V(1).Info("Got ingress ports from dst pods", "port", dedupedPorts)
 
 	return dedupedPorts
 }

--- a/pkg/resolvers/policies_for_pod.go
+++ b/pkg/resolvers/policies_for_pod.go
@@ -42,7 +42,7 @@ func (r *defaultPolicyReferenceResolver) getReferredPoliciesForPod(ctx context.C
 		"policies", referredPolicies)
 
 	for _, ref := range r.policyTracker.GetPoliciesWithNamespaceReferences().UnsortedList() {
-		r.logger.Info("Policy containing namespace selectors", "ref", ref)
+		r.logger.V(1).Info("Policy containing namespace selectors", "ref", ref)
 		if processedPolicies.Has(ref) {
 			continue
 		}
@@ -119,13 +119,11 @@ func (r *defaultPolicyReferenceResolver) isPodLabelMatchPeer(ctx context.Context
 			return false
 		}
 		if !nsSelector.Matches(labels.Set(ns.Labels)) {
-			r.logger.Info("nsSelector does not match ns labels", "selector", nsSelector,
-				"ns", ns)
 			return false
 		}
 
 		if peer.PodSelector == nil {
-			r.logger.Info("nsSelector matches ns labels", "selector", nsSelector,
+			r.logger.V(1).Info("nsSelector matches ns labels", "selector", nsSelector,
 				"ns", ns)
 			return true
 		}
@@ -176,7 +174,7 @@ func (r *defaultPolicyReferenceResolver) getReferredApplicationNetworkPoliciesFo
 	// Second loop: Process cross-namespace ANP policies
 	// Check policies from other namespaces that have namespaceSelector rules
 	for _, ref := range r.policyTracker.GetApplicationNetworkPoliciesWithNamespaceReferences().UnsortedList() {
-		r.logger.Info("ANP Policy containing namespace selectors", "ref", ref)
+		r.logger.V(1).Info("ANP Policy containing namespace selectors", "ref", ref)
 		if processedPolicies.Has(ref) {
 			continue
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
improvement

**Which issue does this PR fix**:
Trim the unnecessary logs, move them to V(1) verbosity for dev debug purpose. no need to show in prod log stream. These logs are supposed for debug purpose, which could create massive logs during pod churns in prod currently.

**What does this PR do / Why do we need it**:


**If an issue # is not available please add steps to reproduce and the controller logs**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!--
List the e2e tests you added as part of this PR.
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new K8s API
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.