### PR TITLE
Fix combineRulesEndpoints to correctly handle allow-all port semantics

### DIFF
--- a/pkg/policyendpoints/manager.go
+++ b/pkg/policyendpoints/manager.go
@@ -291,7 +291,17 @@ func combineRulesEndpoints(ingressEndpoints []policyinfo.EndpointInfo) []policyi
 	for _, iep := range ingressEndpoints {
 		if _, ok := combinedMap[string(iep.CIDR)]; ok {
 			tempIEP := combinedMap[string(iep.CIDR)]
-			tempIEP.Ports = append(combinedMap[string(iep.CIDR)].Ports, iep.Ports...)
+			// Handle port semantics correctly:
+			// - Empty Ports slice means "allow all ports"
+			// - If any rule allows all ports, the combined rule should allow all ports
+			if len(iep.Ports) == 0 {
+				// New rule allows all ports, so combined rule should allow all ports
+				tempIEP.Ports = []policyinfo.Port{}
+			} else if len(tempIEP.Ports) != 0 {
+				// Only append ports if existing rule doesn't already allow all ports
+				tempIEP.Ports = append(combinedMap[string(iep.CIDR)].Ports, iep.Ports...)
+			}
+			// If tempIEP.Ports is already empty (allow all), keep it empty
 			tempIEP.Except = append(combinedMap[string(iep.CIDR)].Except, iep.Except...)
 			combinedMap[string(iep.CIDR)] = tempIEP
 		} else {

--- a/pkg/policyendpoints/manager_test.go
+++ b/pkg/policyendpoints/manager_test.go
@@ -560,6 +560,91 @@ func Test_processPolicyEndpoints(t *testing.T) {
 	assert.Equal(t, 2, len(pes[0].Spec.Egress[0].Ports))
 }
 
+// Test_combineRulesEndpoints_AllowAllPortsSemantics tests that when combining rules for the same CIDR,
+// if any rule allows all ports (empty Ports slice), the combined rule should allow all ports.
+// This addresses GitHub issue #197.
+func Test_combineRulesEndpoints_AllowAllPortsSemantics(t *testing.T) {
+	p53 := int32(53)
+	pTCP := corev1.ProtocolTCP
+	pUDP := corev1.ProtocolUDP
+
+	tests := []struct {
+		name           string
+		inputEndpoints []policyinfo.EndpointInfo
+		wantPortsEmpty bool
+		description    string
+	}{
+		{
+			name: "specific ports then allow all - should allow all",
+			inputEndpoints: []policyinfo.EndpointInfo{
+				{
+					CIDR: "172.16.0.0/12",
+					Ports: []policyinfo.Port{
+						{Port: &p53, Protocol: &pUDP},
+						{Port: &p53, Protocol: &pTCP},
+					},
+				},
+				{
+					CIDR:  "172.16.0.0/12",
+					Ports: []policyinfo.Port{}, // Allow all ports
+				},
+			},
+			wantPortsEmpty: true,
+			description:    "When a rule allows all ports comes after specific ports, combined should allow all",
+		},
+		{
+			name: "allow all then specific ports - should allow all",
+			inputEndpoints: []policyinfo.EndpointInfo{
+				{
+					CIDR:  "172.16.0.0/12",
+					Ports: []policyinfo.Port{}, // Allow all ports
+				},
+				{
+					CIDR: "172.16.0.0/12",
+					Ports: []policyinfo.Port{
+						{Port: &p53, Protocol: &pUDP},
+						{Port: &p53, Protocol: &pTCP},
+					},
+				},
+			},
+			wantPortsEmpty: true,
+			description:    "When a rule allows all ports comes before specific ports, combined should allow all",
+		},
+		{
+			name: "only specific ports - should keep specific ports",
+			inputEndpoints: []policyinfo.EndpointInfo{
+				{
+					CIDR: "172.16.0.0/12",
+					Ports: []policyinfo.Port{
+						{Port: &p53, Protocol: &pUDP},
+					},
+				},
+				{
+					CIDR: "172.16.0.0/12",
+					Ports: []policyinfo.Port{
+						{Port: &p53, Protocol: &pTCP},
+					},
+				},
+			},
+			wantPortsEmpty: false,
+			description:    "When all rules have specific ports, combined should have all those ports",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := combineRulesEndpoints(tt.inputEndpoints)
+			assert.Equal(t, 1, len(result), "Should combine to single CIDR entry")
+
+			if tt.wantPortsEmpty {
+				assert.Empty(t, result[0].Ports, tt.description)
+			} else {
+				assert.NotEmpty(t, result[0].Ports, tt.description)
+			}
+		})
+	}
+}
+
 func Test_policyEndpointsManager_computeApplicationNetworkPolicyEndpoints(t *testing.T) {
 	type args struct {
 		anp                  *policyinfo.ApplicationNetworkPolicy


### PR DESCRIPTION
When combining rules for the same CIDR, if any rule allows all ports (empty Ports slice), the combined rule should allow all ports.

Previously, the function would incorrectly append the empty slice, resulting in policies being more restrictive than intended.

Fixes #197 #193

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add steps to reproduce and the controller logs**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!--
List the e2e tests you added as part of this PR.
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new K8s API
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.