### PR TITLE
metrics improve for adoption and latency

### DIFF
--- a/internal/controllers/policy_controller.go
+++ b/internal/controllers/policy_controller.go
@@ -210,7 +210,7 @@ func (r *policyReconciler) reconcile(ctx context.Context, request reconcile.Requ
 func (r *policyReconciler) reconcileNetworkPolicy(ctx context.Context, networkPolicy *networking.NetworkPolicy) error {
 	start := time.Now()
 	defer func() {
-		metrics.RecordWorkDuration("NetworkPolicy", time.Since(start))
+		metrics.RecordPolicyReconcileLatency("NetworkPolicy", time.Since(start))
 	}()
 
 	isNewPolicy := len(networkPolicy.Finalizers) == 0
@@ -249,7 +249,7 @@ func (r *policyReconciler) cleanupNetworkPolicy(ctx context.Context, networkPoli
 func (r *policyReconciler) reconcileApplicationNetworkPolicy(ctx context.Context, applicationNetworkPolicy *policyinfo.ApplicationNetworkPolicy) error {
 	start := time.Now()
 	defer func() {
-		metrics.RecordWorkDuration("ApplicationNetworkPolicy", time.Since(start))
+		metrics.RecordPolicyReconcileLatency("ApplicationNetworkPolicy", time.Since(start))
 	}()
 
 	isNewPolicy := len(applicationNetworkPolicy.Finalizers) == 0
@@ -288,7 +288,7 @@ func (r *policyReconciler) cleanupApplicationNetworkPolicy(ctx context.Context, 
 func (r *policyReconciler) reconcileClusterNetworkPolicy(ctx context.Context, cnp *policyinfo.ClusterNetworkPolicy) error {
 	start := time.Now()
 	defer func() {
-		metrics.RecordWorkDuration("ClusterNetworkPolicy", time.Since(start))
+		metrics.RecordPolicyReconcileLatency("ClusterNetworkPolicy", time.Since(start))
 	}()
 
 	isNewPolicy := len(cnp.Finalizers) == 0

--- a/internal/controllers/policy_controller.go
+++ b/internal/controllers/policy_controller.go
@@ -213,7 +213,6 @@ func (r *policyReconciler) reconcileNetworkPolicy(ctx context.Context, networkPo
 		metrics.RecordWorkDuration("NetworkPolicy", time.Since(start))
 	}()
 
-	// Check if this is a new policy (no finalizers yet)
 	isNewPolicy := len(networkPolicy.Finalizers) == 0
 
 	if err := r.finalizerManager.AddFinalizers(ctx, networkPolicy, policyFinalizerName); err != nil {
@@ -221,7 +220,6 @@ func (r *policyReconciler) reconcileNetworkPolicy(ctx context.Context, networkPo
 		return err
 	}
 
-	// Increment counter for new policies only
 	if isNewPolicy {
 		metrics.OnPolicyCreated("NetworkPolicy")
 	}
@@ -243,7 +241,6 @@ func (r *policyReconciler) cleanupNetworkPolicy(ctx context.Context, networkPoli
 		if err := r.finalizerManager.RemoveFinalizers(ctx, networkPolicy, policyFinalizerName); err != nil {
 			return err
 		}
-		// Decrement counter when policy is deleted
 		metrics.OnPolicyDeleted("NetworkPolicy")
 	}
 	return nil
@@ -255,7 +252,6 @@ func (r *policyReconciler) reconcileApplicationNetworkPolicy(ctx context.Context
 		metrics.RecordWorkDuration("ApplicationNetworkPolicy", time.Since(start))
 	}()
 
-	// Check if this is a new policy (no finalizers yet)
 	isNewPolicy := len(applicationNetworkPolicy.Finalizers) == 0
 
 	if err := r.finalizerManager.AddFinalizers(ctx, applicationNetworkPolicy, anpFinalizerName); err != nil {
@@ -263,7 +259,6 @@ func (r *policyReconciler) reconcileApplicationNetworkPolicy(ctx context.Context
 		return err
 	}
 
-	// Increment counter for new policies
 	if isNewPolicy {
 		metrics.OnPolicyCreated("ApplicationNetworkPolicy")
 	}
@@ -285,7 +280,6 @@ func (r *policyReconciler) cleanupApplicationNetworkPolicy(ctx context.Context, 
 		if err := r.finalizerManager.RemoveFinalizers(ctx, applicationNetworkPolicy, anpFinalizerName); err != nil {
 			return err
 		}
-		// Decrement counter when policy is deleted
 		metrics.OnPolicyDeleted("ApplicationNetworkPolicy")
 	}
 	return nil
@@ -297,7 +291,6 @@ func (r *policyReconciler) reconcileClusterNetworkPolicy(ctx context.Context, cn
 		metrics.RecordWorkDuration("ClusterNetworkPolicy", time.Since(start))
 	}()
 
-	// Check if this is a new policy (no finalizers yet)
 	isNewPolicy := len(cnp.Finalizers) == 0
 
 	if err := r.finalizerManager.AddFinalizers(ctx, cnp, cnpFinalizerName); err != nil {
@@ -305,7 +298,6 @@ func (r *policyReconciler) reconcileClusterNetworkPolicy(ctx context.Context, cn
 		return err
 	}
 
-	// Increment counter for new policies
 	if isNewPolicy {
 		metrics.OnPolicyCreated("ClusterNetworkPolicy")
 	}
@@ -327,7 +319,6 @@ func (r *policyReconciler) cleanupClusterNetworkPolicy(ctx context.Context, cnp 
 		if err := r.finalizerManager.RemoveFinalizers(ctx, cnp, cnpFinalizerName); err != nil {
 			return err
 		}
-		// Decrement counter when policy is deleted
 		metrics.OnPolicyDeleted("ClusterNetworkPolicy")
 	}
 	return nil

--- a/internal/controllers/policy_controller.go
+++ b/internal/controllers/policy_controller.go
@@ -39,6 +39,7 @@ import (
 	"github.com/aws/amazon-network-policy-controller-k8s/internal/eventhandlers"
 	"github.com/aws/amazon-network-policy-controller-k8s/pkg/config"
 	"github.com/aws/amazon-network-policy-controller-k8s/pkg/k8s"
+	"github.com/aws/amazon-network-policy-controller-k8s/pkg/metrics"
 	"github.com/aws/amazon-network-policy-controller-k8s/pkg/policyendpoints"
 	"github.com/aws/amazon-network-policy-controller-k8s/pkg/resolvers"
 )
@@ -207,10 +208,30 @@ func (r *policyReconciler) reconcile(ctx context.Context, request reconcile.Requ
 }
 
 func (r *policyReconciler) reconcileNetworkPolicy(ctx context.Context, networkPolicy *networking.NetworkPolicy) error {
+	start := time.Now()
+	defer func() {
+		metrics.RecordWorkDuration("NetworkPolicy", time.Since(start))
+	}()
+
+	// Check if this is a new policy (no finalizers yet)
+	isNewPolicy := len(networkPolicy.Finalizers) == 0
+
 	if err := r.finalizerManager.AddFinalizers(ctx, networkPolicy, policyFinalizerName); err != nil {
+		metrics.PolicyReconciliations.WithLabelValues("NetworkPolicy", "error").Inc()
 		return err
 	}
-	return r.policyEndpointsManager.Reconcile(ctx, networkPolicy)
+
+	// Increment counter for new policies only
+	if isNewPolicy {
+		metrics.OnPolicyCreated("NetworkPolicy")
+	}
+
+	if err := r.policyEndpointsManager.Reconcile(ctx, networkPolicy); err != nil {
+		metrics.PolicyReconciliations.WithLabelValues("NetworkPolicy", "error").Inc()
+		return err
+	}
+	metrics.PolicyReconciliations.WithLabelValues("NetworkPolicy", "success").Inc()
+	return nil
 }
 
 func (r *policyReconciler) cleanupNetworkPolicy(ctx context.Context, networkPolicy *networking.NetworkPolicy) error {
@@ -222,15 +243,37 @@ func (r *policyReconciler) cleanupNetworkPolicy(ctx context.Context, networkPoli
 		if err := r.finalizerManager.RemoveFinalizers(ctx, networkPolicy, policyFinalizerName); err != nil {
 			return err
 		}
+		// Decrement counter when policy is deleted
+		metrics.OnPolicyDeleted("NetworkPolicy")
 	}
 	return nil
 }
 
 func (r *policyReconciler) reconcileApplicationNetworkPolicy(ctx context.Context, applicationNetworkPolicy *policyinfo.ApplicationNetworkPolicy) error {
+	start := time.Now()
+	defer func() {
+		metrics.RecordWorkDuration("ApplicationNetworkPolicy", time.Since(start))
+	}()
+
+	// Check if this is a new policy (no finalizers yet)
+	isNewPolicy := len(applicationNetworkPolicy.Finalizers) == 0
+
 	if err := r.finalizerManager.AddFinalizers(ctx, applicationNetworkPolicy, anpFinalizerName); err != nil {
+		metrics.PolicyReconciliations.WithLabelValues("ApplicationNetworkPolicy", "error").Inc()
 		return err
 	}
-	return r.policyEndpointsManager.ReconcileANP(ctx, applicationNetworkPolicy)
+
+	// Increment counter for new policies
+	if isNewPolicy {
+		metrics.OnPolicyCreated("ApplicationNetworkPolicy")
+	}
+
+	if err := r.policyEndpointsManager.ReconcileANP(ctx, applicationNetworkPolicy); err != nil {
+		metrics.PolicyReconciliations.WithLabelValues("ApplicationNetworkPolicy", "error").Inc()
+		return err
+	}
+	metrics.PolicyReconciliations.WithLabelValues("ApplicationNetworkPolicy", "success").Inc()
+	return nil
 }
 
 func (r *policyReconciler) cleanupApplicationNetworkPolicy(ctx context.Context, applicationNetworkPolicy *policyinfo.ApplicationNetworkPolicy) error {
@@ -242,15 +285,37 @@ func (r *policyReconciler) cleanupApplicationNetworkPolicy(ctx context.Context, 
 		if err := r.finalizerManager.RemoveFinalizers(ctx, applicationNetworkPolicy, anpFinalizerName); err != nil {
 			return err
 		}
+		// Decrement counter when policy is deleted
+		metrics.OnPolicyDeleted("ApplicationNetworkPolicy")
 	}
 	return nil
 }
 
 func (r *policyReconciler) reconcileClusterNetworkPolicy(ctx context.Context, cnp *policyinfo.ClusterNetworkPolicy) error {
+	start := time.Now()
+	defer func() {
+		metrics.RecordWorkDuration("ClusterNetworkPolicy", time.Since(start))
+	}()
+
+	// Check if this is a new policy (no finalizers yet)
+	isNewPolicy := len(cnp.Finalizers) == 0
+
 	if err := r.finalizerManager.AddFinalizers(ctx, cnp, cnpFinalizerName); err != nil {
+		metrics.PolicyReconciliations.WithLabelValues("ClusterNetworkPolicy", "error").Inc()
 		return err
 	}
-	return r.policyEndpointsManager.ReconcileCNP(ctx, cnp)
+
+	// Increment counter for new policies
+	if isNewPolicy {
+		metrics.OnPolicyCreated("ClusterNetworkPolicy")
+	}
+
+	if err := r.policyEndpointsManager.ReconcileCNP(ctx, cnp); err != nil {
+		metrics.PolicyReconciliations.WithLabelValues("ClusterNetworkPolicy", "error").Inc()
+		return err
+	}
+	metrics.PolicyReconciliations.WithLabelValues("ClusterNetworkPolicy", "success").Inc()
+	return nil
 }
 
 func (r *policyReconciler) cleanupClusterNetworkPolicy(ctx context.Context, cnp *policyinfo.ClusterNetworkPolicy) error {
@@ -262,6 +327,8 @@ func (r *policyReconciler) cleanupClusterNetworkPolicy(ctx context.Context, cnp 
 		if err := r.finalizerManager.RemoveFinalizers(ctx, cnp, cnpFinalizerName); err != nil {
 			return err
 		}
+		// Decrement counter when policy is deleted
+		metrics.OnPolicyDeleted("ClusterNetworkPolicy")
 	}
 	return nil
 }

--- a/pkg/metrics/policy_metrics.go
+++ b/pkg/metrics/policy_metrics.go
@@ -2,12 +2,13 @@ package metrics
 
 import (
 	"context"
+	"time"
+
 	"github.com/aws/amazon-network-policy-controller-k8s/api/v1alpha1"
 	"github.com/prometheus/client_golang/prometheus"
 	networking "k8s.io/api/networking/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
-	"time"
 )
 
 var (

--- a/pkg/metrics/policy_metrics.go
+++ b/pkg/metrics/policy_metrics.go
@@ -1,0 +1,110 @@
+package metrics
+
+import (
+	"context"
+	"github.com/aws/amazon-network-policy-controller-k8s/api/v1alpha1"
+	"github.com/prometheus/client_golang/prometheus"
+	networking "k8s.io/api/networking/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	"time"
+)
+
+var (
+	PolicyReconciliations = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "network_policy_reconciliations_total",
+			Help: "Total number of policy reconciliations by type and result",
+		},
+		[]string{"policy_type", "result"},
+	)
+
+	PolicyWorkDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "network_policy_workqueue_work_duration_seconds",
+			Help: "How long in seconds processing a policy from workqueue takes",
+		},
+		[]string{"policy_type"},
+	)
+
+	PolicyQueueDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "network_policy_workqueue_queue_duration_seconds",
+			Help: "How long in seconds a policy stays in workqueue before being processed",
+		},
+		[]string{"policy_type"},
+	)
+
+	PolicyObjectCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "network_policy_objects_total",
+			Help: "Total number of policy objects in the cluster by type",
+		},
+		[]string{"policy_type"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(PolicyReconciliations, PolicyWorkDuration, PolicyQueueDuration, PolicyObjectCount)
+}
+
+func RecordWorkDuration(policyType string, duration time.Duration) {
+	PolicyWorkDuration.WithLabelValues(policyType).Observe(duration.Seconds())
+}
+
+func RecordQueueDuration(policyType string, duration time.Duration) {
+	PolicyQueueDuration.WithLabelValues(policyType).Observe(duration.Seconds())
+}
+
+func SetPolicyObjectCount(policyType string, count float64) {
+	PolicyObjectCount.WithLabelValues(policyType).Set(count)
+}
+
+func IncPolicyObjectCount(policyType string) {
+	PolicyObjectCount.WithLabelValues(policyType).Inc()
+}
+
+func DecPolicyObjectCount(policyType string) {
+	PolicyObjectCount.WithLabelValues(policyType).Dec()
+}
+
+// InitializePolicyObjectCounts initializes counters by listing existing policies (called once at startup)
+func InitializePolicyObjectCounts(ctx context.Context, k8sClient client.Client) error {
+	// Initialize NetworkPolicy count
+	var netpols networking.NetworkPolicyList
+	if err := k8sClient.List(ctx, &netpols, &client.ListOptions{}); err != nil {
+		SetPolicyObjectCount("NetworkPolicy", 0)
+	} else {
+		count := float64(len(netpols.Items))
+		SetPolicyObjectCount("NetworkPolicy", count)
+	}
+
+	// Initialize ApplicationNetworkPolicy count
+	var anps v1alpha1.ApplicationNetworkPolicyList
+	if err := k8sClient.List(ctx, &anps, &client.ListOptions{}); err != nil {
+		SetPolicyObjectCount("ApplicationNetworkPolicy", 0)
+	} else {
+		count := float64(len(anps.Items))
+		SetPolicyObjectCount("ApplicationNetworkPolicy", count)
+	}
+
+	// Initialize ClusterNetworkPolicy count
+	var cnps v1alpha1.ClusterNetworkPolicyList
+	if err := k8sClient.List(ctx, &cnps, &client.ListOptions{}); err != nil {
+		SetPolicyObjectCount("ClusterNetworkPolicy", 0)
+	} else {
+		count := float64(len(cnps.Items))
+		SetPolicyObjectCount("ClusterNetworkPolicy", count)
+	}
+
+	return nil
+}
+
+// Event-driven counter updates (no API calls)
+func OnPolicyCreated(policyType string) {
+	IncPolicyObjectCount(policyType)
+}
+
+func OnPolicyDeleted(policyType string) {
+	DecPolicyObjectCount(policyType)
+}

--- a/pkg/metrics/policy_metrics_test.go
+++ b/pkg/metrics/policy_metrics_test.go
@@ -1,0 +1,205 @@
+package metrics
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/amazon-network-policy-controller-k8s/api/v1alpha1"
+	dto "github.com/prometheus/client_model/go"
+	networking "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestRecordWorkDuration(t *testing.T) {
+	// Just test that the function doesn't panic
+	RecordWorkDuration("TestPolicy", 2*time.Second)
+}
+
+func TestRecordQueueDuration(t *testing.T) {
+	// Just test that the function doesn't panic
+	RecordQueueDuration("TestPolicy", 1*time.Second)
+}
+
+func TestSetPolicyObjectCount(t *testing.T) {
+	PolicyObjectCount.Reset()
+
+	SetPolicyObjectCount("TestPolicy", 5)
+
+	metric := &dto.Metric{}
+	PolicyObjectCount.WithLabelValues("TestPolicy").Write(metric)
+
+	if metric.GetGauge().GetValue() != 5 {
+		t.Errorf("Expected count 5, got %f", metric.GetGauge().GetValue())
+	}
+}
+
+func TestIncDecPolicyObjectCount(t *testing.T) {
+	PolicyObjectCount.Reset()
+
+	IncPolicyObjectCount("TestPolicy")
+	IncPolicyObjectCount("TestPolicy")
+
+	metric := &dto.Metric{}
+	PolicyObjectCount.WithLabelValues("TestPolicy").Write(metric)
+
+	if metric.GetGauge().GetValue() != 2 {
+		t.Errorf("Expected count 2 after inc, got %f", metric.GetGauge().GetValue())
+	}
+
+	DecPolicyObjectCount("TestPolicy")
+	PolicyObjectCount.WithLabelValues("TestPolicy").Write(metric)
+
+	if metric.GetGauge().GetValue() != 1 {
+		t.Errorf("Expected count 1 after dec, got %f", metric.GetGauge().GetValue())
+	}
+}
+
+func TestInitializePolicyObjectCounts(t *testing.T) {
+	scheme := runtime.NewScheme()
+	networking.AddToScheme(scheme)
+	v1alpha1.AddToScheme(scheme)
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&networking.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "np1", Namespace: "default"}},
+		&v1alpha1.ApplicationNetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "anp1", Namespace: "default"}},
+		&v1alpha1.ClusterNetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "cnp1"}},
+	).Build()
+
+	PolicyObjectCount.Reset()
+	AdvancedNetworkPolicyEnabled.Set(0)
+
+	err := InitializePolicyObjectCounts(context.Background(), client)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	metric := &dto.Metric{}
+	PolicyObjectCount.WithLabelValues("NetworkPolicy").Write(metric)
+	if metric.GetGauge().GetValue() != 1 {
+		t.Errorf("Expected NetworkPolicy count 1, got %f", metric.GetGauge().GetValue())
+	}
+
+	PolicyObjectCount.WithLabelValues("ApplicationNetworkPolicy").Write(metric)
+	if metric.GetGauge().GetValue() != 1 {
+		t.Errorf("Expected ApplicationNetworkPolicy count 1, got %f", metric.GetGauge().GetValue())
+	}
+
+	PolicyObjectCount.WithLabelValues("ClusterNetworkPolicy").Write(metric)
+	if metric.GetGauge().GetValue() != 1 {
+		t.Errorf("Expected ClusterNetworkPolicy count 1, got %f", metric.GetGauge().GetValue())
+	}
+
+	AdvancedNetworkPolicyEnabled.Write(metric)
+	if metric.GetGauge().GetValue() != 1 {
+		t.Errorf("Expected advanced_network_policy_enabled to be 1, got %f", metric.GetGauge().GetValue())
+	}
+}
+
+func TestAdvancedNetworkPolicyEnabled(t *testing.T) {
+	// Reset metrics
+	PolicyObjectCount.Reset()
+	AdvancedNetworkPolicyEnabled.Set(0)
+
+	// Test case 1: No ANP or CNP policies - should be 0
+	UpdateAdvancedNetworkPolicyEnabled()
+
+	metric := &dto.Metric{}
+	AdvancedNetworkPolicyEnabled.Write(metric)
+
+	if metric.GetGauge().GetValue() != 0 {
+		t.Errorf("Expected advanced_network_policy_enabled to be 0, got %f", metric.GetGauge().GetValue())
+	}
+
+	// Test case 2: Add ANP policy - should be 1
+	SetPolicyObjectCount("ApplicationNetworkPolicy", 1)
+	UpdateAdvancedNetworkPolicyEnabled()
+
+	AdvancedNetworkPolicyEnabled.Write(metric)
+	if metric.GetGauge().GetValue() != 1 {
+		t.Errorf("Expected advanced_network_policy_enabled to be 1 with ANP, got %f", metric.GetGauge().GetValue())
+	}
+
+	// Test case 3: Remove ANP, add CNP - should still be 1
+	SetPolicyObjectCount("ApplicationNetworkPolicy", 0)
+	SetPolicyObjectCount("ClusterNetworkPolicy", 1)
+	UpdateAdvancedNetworkPolicyEnabled()
+
+	AdvancedNetworkPolicyEnabled.Write(metric)
+	if metric.GetGauge().GetValue() != 1 {
+		t.Errorf("Expected advanced_network_policy_enabled to be 1 with CNP, got %f", metric.GetGauge().GetValue())
+	}
+
+	// Test case 4: Both ANP and CNP - should be 1
+	SetPolicyObjectCount("ApplicationNetworkPolicy", 1)
+	SetPolicyObjectCount("ClusterNetworkPolicy", 1)
+	UpdateAdvancedNetworkPolicyEnabled()
+
+	AdvancedNetworkPolicyEnabled.Write(metric)
+	if metric.GetGauge().GetValue() != 1 {
+		t.Errorf("Expected advanced_network_policy_enabled to be 1 with both ANP and CNP, got %f", metric.GetGauge().GetValue())
+	}
+
+	// Test case 5: Only NetworkPolicy, no ANP or CNP - should be 0
+	SetPolicyObjectCount("ApplicationNetworkPolicy", 0)
+	SetPolicyObjectCount("ClusterNetworkPolicy", 0)
+	SetPolicyObjectCount("NetworkPolicy", 5) // Only regular NetworkPolicy
+	UpdateAdvancedNetworkPolicyEnabled()
+
+	AdvancedNetworkPolicyEnabled.Write(metric)
+	if metric.GetGauge().GetValue() != 0 {
+		t.Errorf("Expected advanced_network_policy_enabled to be 0 with only NetworkPolicy, got %f", metric.GetGauge().GetValue())
+	}
+
+	// Test case 6: Remove all - should be 0
+	SetPolicyObjectCount("ApplicationNetworkPolicy", 0)
+	SetPolicyObjectCount("ClusterNetworkPolicy", 0)
+	SetPolicyObjectCount("NetworkPolicy", 0)
+	UpdateAdvancedNetworkPolicyEnabled()
+
+	AdvancedNetworkPolicyEnabled.Write(metric)
+	if metric.GetGauge().GetValue() != 0 {
+		t.Errorf("Expected advanced_network_policy_enabled to be 0 with no policies, got %f", metric.GetGauge().GetValue())
+	}
+}
+
+func TestOnPolicyCreatedAndDeleted(t *testing.T) {
+	// Reset metrics
+	PolicyObjectCount.Reset()
+	AdvancedNetworkPolicyEnabled.Set(0)
+
+	// Create ANP policy
+	OnPolicyCreated("ApplicationNetworkPolicy")
+
+	metric := &dto.Metric{}
+	AdvancedNetworkPolicyEnabled.Write(metric)
+	if metric.GetGauge().GetValue() != 1 {
+		t.Errorf("Expected advanced_network_policy_enabled to be 1 after creating ANP, got %f", metric.GetGauge().GetValue())
+	}
+
+	// Delete ANP policy
+	OnPolicyDeleted("ApplicationNetworkPolicy")
+
+	AdvancedNetworkPolicyEnabled.Write(metric)
+	if metric.GetGauge().GetValue() != 0 {
+		t.Errorf("Expected advanced_network_policy_enabled to be 0 after deleting ANP, got %f", metric.GetGauge().GetValue())
+	}
+
+	// Create NetworkPolicy - should remain 0
+	OnPolicyCreated("NetworkPolicy")
+
+	AdvancedNetworkPolicyEnabled.Write(metric)
+	if metric.GetGauge().GetValue() != 0 {
+		t.Errorf("Expected advanced_network_policy_enabled to be 0 after creating NetworkPolicy, got %f", metric.GetGauge().GetValue())
+	}
+
+	// Delete NetworkPolicy - should still be 0
+	OnPolicyDeleted("NetworkPolicy")
+
+	AdvancedNetworkPolicyEnabled.Write(metric)
+	if metric.GetGauge().GetValue() != 0 {
+		t.Errorf("Expected advanced_network_policy_enabled to be 0 after deleting NetworkPolicy, got %f", metric.GetGauge().GetValue())
+	}
+}

--- a/pkg/metrics/policy_metrics_test.go
+++ b/pkg/metrics/policy_metrics_test.go
@@ -3,7 +3,6 @@ package metrics
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/aws/amazon-network-policy-controller-k8s/api/v1alpha1"
 	dto "github.com/prometheus/client_model/go"
@@ -12,16 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
-
-func TestRecordWorkDuration(t *testing.T) {
-	// Just test that the function doesn't panic
-	RecordWorkDuration("TestPolicy", 2*time.Second)
-}
-
-func TestRecordQueueDuration(t *testing.T) {
-	// Just test that the function doesn't panic
-	RecordQueueDuration("TestPolicy", 1*time.Second)
-}
 
 func TestSetPolicyObjectCount(t *testing.T) {
 	PolicyObjectCount.Reset()
@@ -71,10 +60,7 @@ func TestInitializePolicyObjectCounts(t *testing.T) {
 	PolicyObjectCount.Reset()
 	AdvancedNetworkPolicyEnabled.Set(0)
 
-	err := InitializePolicyObjectCounts(context.Background(), client)
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
+	InitializePolicyObjectCounts(context.Background(), client)
 
 	metric := &dto.Metric{}
 	PolicyObjectCount.WithLabelValues("NetworkPolicy").Write(metric)

--- a/pkg/resolvers/policies_for_pod.go
+++ b/pkg/resolvers/policies_for_pod.go
@@ -38,7 +38,7 @@ func (r *defaultPolicyReferenceResolver) getReferredPoliciesForPod(ctx context.C
 			processedPolicies.Insert(k8s.NamespacedName(&pol))
 		}
 	}
-	r.logger.Info("Policies referred on the same namespace", "pod", k8s.NamespacedName(pod),
+	r.logger.V(1).Info("Policies referred on the same namespace", "pod", k8s.NamespacedName(pod),
 		"policies", referredPolicies)
 
 	for _, ref := range r.policyTracker.GetPoliciesWithNamespaceReferences().UnsortedList() {
@@ -66,7 +66,7 @@ func (r *defaultPolicyReferenceResolver) getReferredPoliciesForPod(ctx context.C
 		}
 	}
 
-	r.logger.Info("All referred policies", "pod", k8s.NamespacedName(pod), "policies", referredPolicies)
+	r.logger.V(1).Info("All referred policies", "pod", k8s.NamespacedName(pod), "policies", referredPolicies)
 	return referredPolicies, nil
 }
 
@@ -168,7 +168,7 @@ func (r *defaultPolicyReferenceResolver) getReferredApplicationNetworkPoliciesFo
 			processedPolicies.Insert(k8s.NamespacedName(&pol))
 		}
 	}
-	r.logger.Info("ANP Policies referred on the same namespace", "pod", k8s.NamespacedName(pod),
+	r.logger.V(1).Info("ANP Policies referred on the same namespace", "pod", k8s.NamespacedName(pod),
 		"policies", referredPolicies)
 
 	// Second loop: Process cross-namespace ANP policies
@@ -198,7 +198,7 @@ func (r *defaultPolicyReferenceResolver) getReferredApplicationNetworkPoliciesFo
 		}
 	}
 
-	r.logger.Info("All referred ANP policies", "pod", k8s.NamespacedName(pod), "policies", referredPolicies)
+	r.logger.V(1).Info("All referred ANP policies", "pod", k8s.NamespacedName(pod), "policies", referredPolicies)
 	return referredPolicies, nil
 }
 

--- a/pkg/resolvers/policies_for_service.go
+++ b/pkg/resolvers/policies_for_service.go
@@ -24,7 +24,7 @@ func (r *defaultPolicyReferenceResolver) getReferredPoliciesForService(ctx conte
 
 	// Get potential matches using the reusable helper
 	potentialMatches := r.getPotentialPolicyMatches(svc, r.policyTracker.GetPoliciesWithEgressRules(), r.policyTracker.GetPoliciesWithNamespaceReferences())
-	r.logger.Info("Potential matches", "policies", potentialMatches.UnsortedList(), "svc", k8s.NamespacedName(svc))
+	r.logger.V(1).Info("Potential matches", "policies", potentialMatches.UnsortedList(), "svc", k8s.NamespacedName(svc))
 
 	var networkPolicyList []networking.NetworkPolicy
 	for policyRef := range potentialMatches {
@@ -58,7 +58,7 @@ func (r *defaultPolicyReferenceResolver) getReferredApplicationNetworkPoliciesFo
 
 	// Get potential ANP matches using the same logic as NetworkPolicy
 	potentialMatches := r.getPotentialPolicyMatches(svc, r.policyTracker.GetApplicationNetworkPoliciesWithEgressRules(), r.policyTracker.GetApplicationNetworkPoliciesWithNamespaceReferences())
-	r.logger.Info("Potential ANP matches", "policies", potentialMatches.UnsortedList(), "svc", k8s.NamespacedName(svc))
+	r.logger.V(1).Info("Potential ANP matches", "policies", potentialMatches.UnsortedList(), "svc", k8s.NamespacedName(svc))
 
 	var anpList []policyinfo.ApplicationNetworkPolicy
 	for policyRef := range potentialMatches {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
-->
**What type of PR is this?**
- Added granular reconcile metrics per policy types
- Added adoption metrics
- Moved some debug log to V(1) to avoid flood production logs.
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
metrics improvement

**What does this PR do / Why do we need it**:


**If an issue # is not available please add steps to reproduce and the controller logs**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Deployed locally. Tested the metrics with policies CRUD
```
1# HELP advanced_network_policy_enabled Indicates if advanced network policies (ANP or CNP) are in use (1 if enabled, 0 if disabled)
00# TYPE advanced_network_policy_enabled gauge
 advanced_network_policy_enabled 1
58197    0 58# HELP network_policy_objects_total Total number of policy objects in the cluster by type
19# TYPE network_policy_objects_total gauge
7network_policy_objects_total{policy_type="ApplicationNetworkPolicy"} 1
  network_policy_objects_total{policy_type="ClusterNetworkPolicy"} 1
  network_policy_objects_total{policy_type="NetworkPolicy"} 1
0 # HELP network_policy_reconcile_duration_seconds How long in seconds reconciling a policy takes
 # TYPE network_policy_reconcile_duration_seconds histogram
  network_policy_reconcile_duration_seconds_bucket{policy_type="ApplicationNetworkPolicy",le="0.005"} 0
 0network_policy_reconcile_duration_seconds_bucket{policy_type="ApplicationNetworkPolicy",le="0.01"} 0
  network_policy_reconcile_duration_seconds_bucket{policy_type="ApplicationNetworkPolicy",le="0.025"} 2
51network_policy_reconcile_duration_seconds_bucket{policy_type="ApplicationNetworkPolicy",le="0.05"} 2
7network_policy_reconcile_duration_seconds_bucket{policy_type="ApplicationNetworkPolicy",le="0.1"} 2
3knetwork_policy_reconcile_duration_seconds_bucket{policy_type="ApplicationNetworkPolicy",le="0.25"} 2
  network_policy_reconcile_duration_seconds_bucket{policy_type="ApplicationNetworkPolicy",le="0.5"} 2
  network_policy_reconcile_duration_seconds_bucket{policy_type="ApplicationNetworkPolicy",le="1"} 2
  network_policy_reconcile_duration_seconds_bucket{policy_type="ApplicationNetworkPolicy",le="2.5"} 2
0 network_policy_reconcile_duration_seconds_bucket{policy_type="ApplicationNetworkPolicy",le="5"} 2
--network_policy_reconcile_duration_seconds_bucket{policy_type="ApplicationNetworkPolicy",le="10"} 2
:-network_policy_reconcile_duration_seconds_bucket{policy_type="ApplicationNetworkPolicy",le="+Inf"} 2
-:network_policy_reconcile_duration_seconds_sum{policy_type="ApplicationNetworkPolicy"} 0.028163029
--network_policy_reconcile_duration_seconds_count{policy_type="ApplicationNetworkPolicy"} 2
 network_policy_reconcile_duration_seconds_bucket{policy_type="ClusterNetworkPolicy",le="0.005"} 0
--network_policy_reconcile_duration_seconds_bucket{policy_type="ClusterNetworkPolicy",le="0.01"} 0
:network_policy_reconcile_duration_seconds_bucket{policy_type="ClusterNetworkPolicy",le="0.025"} 2
--network_policy_reconcile_duration_seconds_bucket{policy_type="ClusterNetworkPolicy",le="0.05"} 2
:network_policy_reconcile_duration_seconds_bucket{policy_type="ClusterNetworkPolicy",le="0.1"} 2
--network_policy_reconcile_duration_seconds_bucket{policy_type="ClusterNetworkPolicy",le="0.25"} 2
 -network_policy_reconcile_duration_seconds_bucket{policy_type="ClusterNetworkPolicy",le="0.5"} 2
-network_policy_reconcile_duration_seconds_bucket{policy_type="ClusterNetworkPolicy",le="1"} 2
:-network_policy_reconcile_duration_seconds_bucket{policy_type="ClusterNetworkPolicy",le="2.5"} 2
-:network_policy_reconcile_duration_seconds_bucket{policy_type="ClusterNetworkPolicy",le="5"} 2
--network_policy_reconcile_duration_seconds_bucket{policy_type="ClusterNetworkPolicy",le="10"} 2
 5network_policy_reconcile_duration_seconds_bucket{policy_type="ClusterNetworkPolicy",le="+Inf"} 2
6network_policy_reconcile_duration_seconds_sum{policy_type="ClusterNetworkPolicy"} 0.031974702
83network_policy_reconcile_duration_seconds_count{policy_type="ClusterNetworkPolicy"} 2
knetwork_policy_reconcile_duration_seconds_bucket{policy_type="NetworkPolicy",le="0.005"} 1

network_policy_reconcile_duration_seconds_bucket{policy_type="NetworkPolicy",le="0.01"} 1
network_policy_reconcile_duration_seconds_bucket{policy_type="NetworkPolicy",le="0.025"} 1
network_policy_reconcile_duration_seconds_bucket{policy_type="NetworkPolicy",le="0.05"} 1
network_policy_reconcile_duration_seconds_bucket{policy_type="NetworkPolicy",le="0.1"} 1
network_policy_reconcile_duration_seconds_bucket{policy_type="NetworkPolicy",le="0.25"} 1
network_policy_reconcile_duration_seconds_bucket{policy_type="NetworkPolicy",le="0.5"} 1
network_policy_reconcile_duration_seconds_bucket{policy_type="NetworkPolicy",le="1"} 1
network_policy_reconcile_duration_seconds_bucket{policy_type="NetworkPolicy",le="2.5"} 1
network_policy_reconcile_duration_seconds_bucket{policy_type="NetworkPolicy",le="5"} 1
network_policy_reconcile_duration_seconds_bucket{policy_type="NetworkPolicy",le="10"} 1
network_policy_reconcile_duration_seconds_bucket{policy_type="NetworkPolicy",le="+Inf"} 1
network_policy_reconcile_duration_seconds_sum{policy_type="NetworkPolicy"} 0.000288743
network_policy_reconcile_duration_seconds_count{policy_type="NetworkPolicy"} 1
# HELP network_policy_reconciliations_total Total number of policy reconciliations by type and result
# TYPE network_policy_reconciliations_total counter
network_policy_reconciliations_total{policy_type="ApplicationNetworkPolicy",result="success"} 2
network_policy_reconciliations_total{policy_type="ClusterNetworkPolicy",result="success"} 2
network_policy_reconciliations_total{policy_type="NetworkPolicy",result="success"} 1
```
**Automation added to e2e**:
<!--
List the e2e tests you added as part of this PR.
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new K8s API
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.