### PR TITLE
fixing Service named port bypass issue

### DIFF
--- a/pkg/resolvers/endpoints_test.go
+++ b/pkg/resolvers/endpoints_test.go
@@ -1480,3 +1480,669 @@ func TestEndpointsResolver_IncludesHostNetworkPodsInIngressEgressRules(t *testin
 	assert.True(t, egressCIDRs["192.168.1.3"], "hostNetwork database pod IP should be included in egress rules")
 	assert.True(t, egressCIDRs["10.0.0.3"], "regular database pod IP should be included in egress rules")
 }
+
+func TestEndpointsResolver_NamedPortBypassIssue(t *testing.T) {
+	protocolTCP := corev1.ProtocolTCP
+	port80 := int32(80)
+	intOrStrPort80 := intstr.FromInt(int(port80))
+	intOrStrPort8080 := intstr.FromInt(8080)
+	namedPortHTTP := intstr.FromString("http")
+
+	// Pod A: named port "http" = 80
+	nginxPod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nginx-pod",
+			Namespace: "test-ns",
+			Labels:    map[string]string{"shared-backend": "true"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "nginx",
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          "http",
+							ContainerPort: 80,
+							Protocol:      corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			PodIP: "192.168.10.156",
+			Phase: corev1.PodRunning,
+		},
+	}
+
+	// Pod B: named port "http" = 8080 (different container port for same named port)
+	pythonPod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "python-pod",
+			Namespace: "test-ns",
+			Labels:    map[string]string{"shared-backend": "true"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "python",
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          "http",
+							ContainerPort: 8080,
+							Protocol:      corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			PodIP: "192.168.26.219",
+			Phase: corev1.PodRunning,
+		},
+	}
+
+	// Service with named targetPort selecting both pods
+	problematicService := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shared-backend-svc",
+			Namespace: "test-ns",
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.100.76.99",
+			Selector:  map[string]string{"shared-backend": "true"},
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "http",
+					Port:       80,
+					TargetPort: intstr.FromString("http"), // Named targetPort
+					Protocol:   corev1.ProtocolTCP,
+				},
+			},
+		},
+	}
+
+	// Service with numeric targetPort (not problematic)
+	safeService := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "safe-svc",
+			Namespace: "test-ns",
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.100.76.100",
+			Selector:  map[string]string{"shared-backend": "true"},
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "http",
+					Port:       80,
+					TargetPort: intstr.FromInt(80), // Numeric targetPort
+					Protocol:   corev1.ProtocolTCP,
+				},
+			},
+		},
+	}
+
+	// Pods with consistent named port resolution (not problematic)
+	consistentPod1 := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "consistent-pod-1",
+			Namespace: "test-ns",
+			Labels:    map[string]string{"consistent-backend": "true"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "app",
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          "http",
+							ContainerPort: 8080,
+							Protocol:      corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			PodIP: "192.168.10.200",
+			Phase: corev1.PodRunning,
+		},
+	}
+
+	consistentPod2 := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "consistent-pod-2",
+			Namespace: "test-ns",
+			Labels:    map[string]string{"consistent-backend": "true"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "app",
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          "http",
+							ContainerPort: 8080, // Same as consistentPod1
+							Protocol:      corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			PodIP: "192.168.10.201",
+			Phase: corev1.PodRunning,
+		},
+	}
+
+	// Service with named targetPort that matches the policy port value
+	consistentServiceWithMatchingPort := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "consistent-svc-matching",
+			Namespace: "test-ns",
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.100.76.102",
+			Selector:  map[string]string{"consistent-backend": "true"},
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "http",
+					Port:       80,
+					TargetPort: intstr.FromInt(80), // Numeric targetPort that matches policy
+					Protocol:   corev1.ProtocolTCP,
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name                     string
+		policy                   *networking.NetworkPolicy
+		pods                     []corev1.Pod
+		services                 []corev1.Service
+		expectServiceClusterIPs  []string // ClusterIPs that should be in the result
+		excludeServiceClusterIPs []string // ClusterIPs that should NOT be in the result
+	}{
+		{
+			name: "problematic: numeric policy port + named targetPort + inconsistent container ports",
+			policy: &networking.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "allow-egress-port-80-only",
+					Namespace: "test-ns",
+				},
+				Spec: networking.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"role": "client"},
+					},
+					PolicyTypes: []networking.PolicyType{networking.PolicyTypeEgress},
+					Egress: []networking.NetworkPolicyEgressRule{
+						{
+							To: []networking.NetworkPolicyPeer{
+								{
+									PodSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"shared-backend": "true"},
+									},
+								},
+							},
+							Ports: []networking.NetworkPolicyPort{
+								{
+									Protocol: &protocolTCP,
+									Port:     &intOrStrPort80, // Numeric port
+								},
+							},
+						},
+					},
+				},
+			},
+			pods:                     []corev1.Pod{nginxPod, pythonPod},
+			services:                 []corev1.Service{problematicService},
+			expectServiceClusterIPs:  []string{}, // Should NOT include problematic service
+			excludeServiceClusterIPs: []string{problematicService.Spec.ClusterIP},
+		},
+		{
+			name: "safe: named policy port (intentional per-pod resolution)",
+			policy: &networking.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "allow-egress-named-port",
+					Namespace: "test-ns",
+				},
+				Spec: networking.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"role": "client"},
+					},
+					PolicyTypes: []networking.PolicyType{networking.PolicyTypeEgress},
+					Egress: []networking.NetworkPolicyEgressRule{
+						{
+							To: []networking.NetworkPolicyPeer{
+								{
+									PodSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"shared-backend": "true"},
+									},
+								},
+							},
+							Ports: []networking.NetworkPolicyPort{
+								{
+									Protocol: &protocolTCP,
+									Port:     &namedPortHTTP, // Named port in policy - intentional
+								},
+							},
+						},
+					},
+				},
+			},
+			pods:                    []corev1.Pod{nginxPod, pythonPod},
+			services:                []corev1.Service{problematicService},
+			expectServiceClusterIPs: []string{problematicService.Spec.ClusterIP}, // Should include - named port is intentional
+		},
+		{
+			name: "safe: numeric targetPort in service",
+			policy: &networking.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "allow-egress-port-80",
+					Namespace: "test-ns",
+				},
+				Spec: networking.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"role": "client"},
+					},
+					PolicyTypes: []networking.PolicyType{networking.PolicyTypeEgress},
+					Egress: []networking.NetworkPolicyEgressRule{
+						{
+							To: []networking.NetworkPolicyPeer{
+								{
+									PodSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"shared-backend": "true"},
+									},
+								},
+							},
+							Ports: []networking.NetworkPolicyPort{
+								{
+									Protocol: &protocolTCP,
+									Port:     &intOrStrPort80,
+								},
+							},
+						},
+					},
+				},
+			},
+			pods:                    []corev1.Pod{nginxPod, pythonPod},
+			services:                []corev1.Service{safeService},
+			expectServiceClusterIPs: []string{safeService.Spec.ClusterIP}, // Should include - numeric targetPort is safe
+		},
+		{
+			name: "safe: consistent named port resolution across pods",
+			policy: &networking.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "allow-egress-port-80",
+					Namespace: "test-ns",
+				},
+				Spec: networking.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"role": "client"},
+					},
+					PolicyTypes: []networking.PolicyType{networking.PolicyTypeEgress},
+					Egress: []networking.NetworkPolicyEgressRule{
+						{
+							To: []networking.NetworkPolicyPeer{
+								{
+									PodSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"consistent-backend": "true"},
+									},
+								},
+							},
+							Ports: []networking.NetworkPolicyPort{
+								{
+									Protocol: &protocolTCP,
+									Port:     &intOrStrPort80,
+								},
+							},
+						},
+					},
+				},
+			},
+			pods:                    []corev1.Pod{consistentPod1, consistentPod2},
+			services:                []corev1.Service{consistentServiceWithMatchingPort},
+			expectServiceClusterIPs: []string{consistentServiceWithMatchingPort.Spec.ClusterIP}, // Should include - consistent resolution
+		},
+		{
+			name: "safe: policy allows all ports that service remaps to",
+			policy: &networking.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "allow-egress-all-remapped-ports",
+					Namespace: "test-ns",
+				},
+				Spec: networking.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"role": "client"},
+					},
+					PolicyTypes: []networking.PolicyType{networking.PolicyTypeEgress},
+					Egress: []networking.NetworkPolicyEgressRule{
+						{
+							To: []networking.NetworkPolicyPeer{
+								{
+									PodSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"shared-backend": "true"},
+									},
+								},
+							},
+							Ports: []networking.NetworkPolicyPort{
+								{
+									Protocol: &protocolTCP,
+									Port:     &intOrStrPort80, // Allows port 80 (nginxPod)
+								},
+								{
+									Protocol: &protocolTCP,
+									Port:     &intOrStrPort8080, // Allows port 8080 (pythonPod)
+								},
+							},
+						},
+					},
+				},
+			},
+			pods:                    []corev1.Pod{nginxPod, pythonPod},
+			services:                []corev1.Service{problematicService},
+			expectServiceClusterIPs: []string{problematicService.Spec.ClusterIP}, // Should include - all remapped ports are allowed
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockClient := mock_client.NewMockClient(ctrl)
+			resolver := NewEndpointsResolver(mockClient, logr.New(&log.NullLogSink{}))
+
+			// Setup mock expectations
+			podList := &corev1.PodList{}
+			serviceList := &corev1.ServiceList{}
+
+			// Mock pod list calls (may be called multiple times)
+			mockClient.EXPECT().List(gomock.Any(), podList, gomock.Any()).DoAndReturn(
+				func(ctx context.Context, list *corev1.PodList, opts ...client.ListOption) error {
+					list.Items = tt.pods
+					return nil
+				},
+			).AnyTimes()
+
+			// Mock service list calls
+			mockClient.EXPECT().List(gomock.Any(), serviceList, gomock.Any()).DoAndReturn(
+				func(ctx context.Context, list *corev1.ServiceList, opts ...client.ListOption) error {
+					list.Items = tt.services
+					return nil
+				},
+			).AnyTimes()
+
+			_, egressEndpoints, _, err := resolver.Resolve(context.Background(), tt.policy)
+			require.NoError(t, err)
+
+			// Extract ClusterIPs from egress endpoints
+			var foundClusterIPs []string
+			for _, ep := range egressEndpoints {
+				for _, svc := range tt.services {
+					if string(ep.CIDR) == svc.Spec.ClusterIP {
+						foundClusterIPs = append(foundClusterIPs, string(ep.CIDR))
+					}
+				}
+			}
+
+			// Check expected ClusterIPs are present
+			for _, expectedIP := range tt.expectServiceClusterIPs {
+				found := false
+				for _, ip := range foundClusterIPs {
+					if ip == expectedIP {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "Expected ClusterIP %s to be in egress endpoints", expectedIP)
+			}
+
+			// Check excluded ClusterIPs are NOT present
+			for _, excludedIP := range tt.excludeServiceClusterIPs {
+				found := false
+				for _, ip := range foundClusterIPs {
+					if ip == excludedIP {
+						found = true
+						break
+					}
+				}
+				assert.False(t, found, "ClusterIP %s should NOT be in egress endpoints (problematic)", excludedIP)
+			}
+		})
+	}
+}
+
+func TestEndpointsResolver_hasNamedPortBypassIssue(t *testing.T) {
+	protocolTCP := corev1.ProtocolTCP
+	port80 := int32(80)
+	intOrStrPort80 := intstr.FromInt(int(port80))
+	intOrStrPort8080 := intstr.FromInt(8080)
+	namedPortHTTP := intstr.FromString("http")
+
+	tests := []struct {
+		name        string
+		service     *corev1.Service
+		policyPorts []networking.NetworkPolicyPort
+		pods        []corev1.Pod
+		expected    bool
+	}{
+		{
+			name: "problematic: numeric policy port + named targetPort + inconsistent container ports",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "ns"},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "10.0.0.1",
+					Selector:  map[string]string{"app": "test"},
+					Ports: []corev1.ServicePort{
+						{TargetPort: intstr.FromString("http"), Protocol: corev1.ProtocolTCP},
+					},
+				},
+			},
+			policyPorts: []networking.NetworkPolicyPort{
+				{Protocol: &protocolTCP, Port: &intOrStrPort80},
+			},
+			pods: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "ns", Labels: map[string]string{"app": "test"}},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Ports: []corev1.ContainerPort{{Name: "http", ContainerPort: 80}}},
+						},
+					},
+					Status: corev1.PodStatus{PodIP: "1.0.0.1", Phase: corev1.PodRunning},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: "ns", Labels: map[string]string{"app": "test"}},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Ports: []corev1.ContainerPort{{Name: "http", ContainerPort: 8080}}}, // Different!
+						},
+					},
+					Status: corev1.PodStatus{PodIP: "1.0.0.2", Phase: corev1.PodRunning},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "safe: named policy port",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "ns"},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "10.0.0.1",
+					Selector:  map[string]string{"app": "test"},
+					Ports: []corev1.ServicePort{
+						{TargetPort: intstr.FromString("http"), Protocol: corev1.ProtocolTCP},
+					},
+				},
+			},
+			policyPorts: []networking.NetworkPolicyPort{
+				{Protocol: &protocolTCP, Port: &namedPortHTTP}, // Named port in policy
+			},
+			pods: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "ns", Labels: map[string]string{"app": "test"}},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Ports: []corev1.ContainerPort{{Name: "http", ContainerPort: 80}}},
+						},
+					},
+					Status: corev1.PodStatus{PodIP: "1.0.0.1", Phase: corev1.PodRunning},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: "ns", Labels: map[string]string{"app": "test"}},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Ports: []corev1.ContainerPort{{Name: "http", ContainerPort: 8080}}},
+						},
+					},
+					Status: corev1.PodStatus{PodIP: "1.0.0.2", Phase: corev1.PodRunning},
+				},
+			},
+			expected: false, // Named port in policy is intentional
+		},
+		{
+			name: "safe: numeric targetPort in service",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "ns"},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "10.0.0.1",
+					Selector:  map[string]string{"app": "test"},
+					Ports: []corev1.ServicePort{
+						{TargetPort: intstr.FromInt(80), Protocol: corev1.ProtocolTCP}, // Numeric targetPort
+					},
+				},
+			},
+			policyPorts: []networking.NetworkPolicyPort{
+				{Protocol: &protocolTCP, Port: &intOrStrPort80},
+			},
+			pods: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "ns", Labels: map[string]string{"app": "test"}},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Ports: []corev1.ContainerPort{{Name: "http", ContainerPort: 80}}},
+						},
+					},
+					Status: corev1.PodStatus{PodIP: "1.0.0.1", Phase: corev1.PodRunning},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "safe: consistent named port resolution",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "ns"},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "10.0.0.1",
+					Selector:  map[string]string{"app": "test"},
+					Ports: []corev1.ServicePort{
+						{TargetPort: intstr.FromString("http"), Protocol: corev1.ProtocolTCP},
+					},
+				},
+			},
+			policyPorts: []networking.NetworkPolicyPort{
+				{Protocol: &protocolTCP, Port: &intOrStrPort80},
+			},
+			pods: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "ns", Labels: map[string]string{"app": "test"}},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Ports: []corev1.ContainerPort{{Name: "http", ContainerPort: 8080}}},
+						},
+					},
+					Status: corev1.PodStatus{PodIP: "1.0.0.1", Phase: corev1.PodRunning},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: "ns", Labels: map[string]string{"app": "test"}},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Ports: []corev1.ContainerPort{{Name: "http", ContainerPort: 8080}}}, // Same as pod1
+						},
+					},
+					Status: corev1.PodStatus{PodIP: "1.0.0.2", Phase: corev1.PodRunning},
+				},
+			},
+			expected: false, // Consistent resolution is safe
+		},
+		{
+			name: "safe: no policy ports specified",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "ns"},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "10.0.0.1",
+					Selector:  map[string]string{"app": "test"},
+					Ports: []corev1.ServicePort{
+						{TargetPort: intstr.FromString("http"), Protocol: corev1.ProtocolTCP},
+					},
+				},
+			},
+			policyPorts: []networking.NetworkPolicyPort{}, // No ports = all ports allowed
+			pods: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "ns", Labels: map[string]string{"app": "test"}},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Ports: []corev1.ContainerPort{{Name: "http", ContainerPort: 80}}},
+						},
+					},
+					Status: corev1.PodStatus{PodIP: "1.0.0.1", Phase: corev1.PodRunning},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "safe: policy allows all remapped container ports",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "ns"},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "10.0.0.1",
+					Selector:  map[string]string{"app": "test"},
+					Ports: []corev1.ServicePort{
+						{TargetPort: intstr.FromString("http"), Protocol: corev1.ProtocolTCP},
+					},
+				},
+			},
+			policyPorts: []networking.NetworkPolicyPort{
+				{Protocol: &protocolTCP, Port: &intOrStrPort80},
+				{Protocol: &protocolTCP, Port: &intOrStrPort8080},
+			},
+			pods: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "ns", Labels: map[string]string{"app": "test"}},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Ports: []corev1.ContainerPort{{Name: "http", ContainerPort: 80}}},
+						},
+					},
+					Status: corev1.PodStatus{PodIP: "1.0.0.1", Phase: corev1.PodRunning},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: "ns", Labels: map[string]string{"app": "test"}},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Ports: []corev1.ContainerPort{{Name: "http", ContainerPort: 8080}}},
+						},
+					},
+					Status: corev1.PodStatus{PodIP: "1.0.0.2", Phase: corev1.PodRunning},
+				},
+			},
+			expected: false, // All container ports are allowed by policy
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockClient := mock_client.NewMockClient(ctrl)
+			resolver := NewEndpointsResolver(mockClient, logr.New(&log.NullLogSink{}))
+
+			// Pass pods directly to the function (no longer needs context or client)
+			result := resolver.hasNamedPortBypassIssue(tt.service, tt.policyPorts, tt.pods)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
-->
**What type of PR is this?**
bugfix

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:

Fixes a security bypass in PolicyEndpoint generation where Service ClusterIPs are incorrectly added to egress rules, allowing traffic to reach ports that should be blocked by NetworkPolicy.

When a NetworkPolicy restricts egress to a specific numeric port (e.g., port: 80) using a podSelector, and a matching Service uses a named targetPort (e.g., targetPort: http) backed by pods that resolve that named port to different container ports (e.g., pod A has http=80, pod B has http=8080), the Service ClusterIP gets added to the PolicyEndpoint. Since the eBPF agent enforces policy at the TC hook (pre-DNAT), it sees ClusterIP:80 as allowed, but kube-proxy may DNAT the traffic to pod B:8080, bypassing the policy's port restriction.

This PR skips adding the Service ClusterIP to the PolicyEndpoint when all three conditions are met: the policy uses a numeric port, the service uses a named targetPort, and pods behind the service resolve that named port inconsistently to container ports not covered by the policy. Cases where the policy itself uses a named port are unaffected — that's intentional per-pod resolution by design.

**What does this PR do / Why do we need it**:
bug fix

**If an issue # is not available please add steps to reproduce and the controller logs**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
- tried this specific Service named port re-mapped case and validated its skipped (UT and manual test)
- ran cyclonus test

**Automation added to e2e**:
<!--
List the e2e tests you added as part of this PR.
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**: NO
<!--
e.g. new K8s API
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**: NO


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
Yes, Skipping ServiceIP addition in PolicyEndpoint where its re-mapped to different container ports and if not allowed by Network Policy

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.