### PR TITLE
added change timestamp in PE and CPE annotation

### DIFF
--- a/pkg/policyendpoints/manager.go
+++ b/pkg/policyendpoints/manager.go
@@ -737,6 +737,14 @@ func (m *policyEndpointsManager) ReconcileCNP(ctx context.Context, cnp *policyin
 	}
 
 	for i := range updateList {
+		oldRes := &policyinfo.ClusterPolicyEndpoint{}
+		if err := m.k8sClient.Get(ctx, k8s.NamespacedName(&updateList[i]), oldRes); err != nil {
+			return err
+		}
+		if equality.Semantic.DeepEqual(oldRes.Spec, updateList[i].Spec) {
+			m.logger.V(1).Info("Cluster policy endpoint already up to date", "id", k8s.NamespacedName(&updateList[i]))
+			continue
+		}
 		setLastChangeTriggerTimeOnCPE(&updateList[i])
 		if err := m.k8sClient.Update(ctx, &updateList[i]); err != nil {
 			return err

--- a/pkg/policyendpoints/manager_test.go
+++ b/pkg/policyendpoints/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
@@ -1105,6 +1106,49 @@ type mockCNPEndpointsResolver struct {
 func (m *mockCNPEndpointsResolver) ResolveClusterNetworkPolicy(ctx context.Context, cnp *policyinfo.ClusterNetworkPolicy) ([]policyinfo.ClusterEndpointInfo, []policyinfo.ClusterEndpointInfo, []policyinfo.PodEndpoint, error) {
 	m.called = true
 	return m.ingressRules, m.egressRules, m.podEndpoints, nil
+}
+
+func Test_setLastChangeTriggerTime(t *testing.T) {
+	t.Run("sets annotation on PE with nil annotations", func(t *testing.T) {
+		pe := &policyinfo.PolicyEndpoint{}
+		before := time.Now().UTC()
+		setLastChangeTriggerTime(pe)
+		after := time.Now().UTC()
+
+		val, ok := pe.Annotations[LastChangeTriggerTimeAnnotation]
+		assert.True(t, ok)
+		ts, err := time.Parse(time.RFC3339Nano, val)
+		assert.NoError(t, err)
+		assert.False(t, ts.Before(before))
+		assert.False(t, ts.After(after))
+	})
+
+	t.Run("preserves existing annotations on PE", func(t *testing.T) {
+		pe := &policyinfo.PolicyEndpoint{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{"existing-key": "existing-value"},
+			},
+		}
+		setLastChangeTriggerTime(pe)
+
+		assert.Equal(t, "existing-value", pe.Annotations["existing-key"])
+		_, ok := pe.Annotations[LastChangeTriggerTimeAnnotation]
+		assert.True(t, ok)
+	})
+
+	t.Run("sets annotation on CPE with nil annotations", func(t *testing.T) {
+		cpe := &policyinfo.ClusterPolicyEndpoint{}
+		before := time.Now().UTC()
+		setLastChangeTriggerTimeOnCPE(cpe)
+		after := time.Now().UTC()
+
+		val, ok := cpe.Annotations[LastChangeTriggerTimeAnnotation]
+		assert.True(t, ok)
+		ts, err := time.Parse(time.RFC3339Nano, val)
+		assert.NoError(t, err)
+		assert.False(t, ts.Before(before))
+		assert.False(t, ts.After(after))
+	})
 }
 
 func Test_combineClusterRulesEndpoints(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
-->
**What type of PR is this?**
feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:
Adds a `networking.k8s.aws/last-change-trigger-time` annotation to PolicyEndpoint and ClusterPolicyEndpoint resources. This annotation is set whenever NPC creates or updates these resources, recording the timestamp in RFC3339Nano format.

This enables the Network Policy Agent (NPA) to compute end-to-end policy programming latency by comparing when the controller made changes versus when they were applied. The pattern mirrors kube-proxy's endpoints.kubernetes.io/last-change-trigger-time annotation on EndpointSlice.

**If an issue # is not available please add steps to reproduce and the controller logs**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
tested by deployment. 

```
apiVersion: networking.k8s.aws/v1alpha1
kind: PolicyEndpoint
metadata:
  annotations:
    networking.k8s.aws/last-change-trigger-time: "2026-02-19T23:51:44.942777624Z"
  creationTimestamp: "2026-02-19T23:16:34Z"
  generateName: kwok-scale-test-policy-91-
  generation: 30
  name: kwok-scale-test-policy-91-hwj5w
  namespace: scale-test
```

**Automation added to e2e**:
<!--
List the e2e tests you added as part of this PR.
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new K8s API
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.