### PR TITLE
fixed: bypass logic for same named port containers in a pod

### DIFF
--- a/pkg/resolvers/endpoints.go
+++ b/pkg/resolvers/endpoints.go
@@ -550,26 +550,19 @@ func (r *defaultEndpointsResolver) hasTargetPortBypass(svc *corev1.Service, matc
 		if !svcSelector.Matches(labels.Set(pod.Labels)) {
 			continue
 		}
-		for j := range pod.Spec.Containers {
-			container := &pod.Spec.Containers[j]
-			for k := range container.Ports {
-				cp := container.Ports[k]
-				if cp.Name == targetPortName {
-					cpProto := cp.Protocol
-					if cpProto == "" {
-						cpProto = corev1.ProtocolTCP
-					}
-					if !isNumericPortAllowed(cp.ContainerPort, cpProto, policyPorts) {
-						r.logger.Info("Named port resolves to disallowed container port",
-							"service", k8s.NamespacedName(svc),
-							"pod", k8s.NamespacedName(pod),
-							"container", container.Name,
-							"portName", cp.Name,
-							"containerPort", cp.ContainerPort, "protocol", cpProto)
-						return true
-					}
-				}
-			}
+		// Resolve the named port using the first matching container port, matching
+		// Kubernetes EndpointSlice controller behavior for svc resolution.
+		cp, found := firstNamedPort(pod, targetPortName, protocol)
+		if !found {
+			continue
+		}
+		if !isNumericPortAllowed(cp.ContainerPort, protocol, policyPorts) {
+			r.logger.Info("Named port resolves to disallowed container port",
+				"service", k8s.NamespacedName(svc),
+				"pod", k8s.NamespacedName(pod),
+				"portName", cp.Name,
+				"containerPort", cp.ContainerPort, "protocol", protocol)
+			return true
 		}
 	}
 	return false
@@ -607,6 +600,25 @@ func isNumericPortAllowed(port int32, protocol corev1.Protocol, policyPorts []ne
 		}
 	}
 	return false
+}
+
+// firstNamedPort returns the first container port matching the given name and protocol in a pod.
+// This mirrors how Kubernetes EndpointSlice controller resolves named targetPorts — it picks the
+// first matching container port across all containers in declaration order.
+func firstNamedPort(pod *corev1.Pod, portName string, protocol corev1.Protocol) (corev1.ContainerPort, bool) {
+	for i := range pod.Spec.Containers {
+		for j := range pod.Spec.Containers[i].Ports {
+			cp := pod.Spec.Containers[i].Ports[j]
+			cpProto := cp.Protocol
+			if cpProto == "" {
+				cpProto = corev1.ProtocolTCP
+			}
+			if cp.Name == portName && cpProto == protocol {
+				return cp, true
+			}
+		}
+	}
+	return corev1.ContainerPort{}, false
 }
 
 // getMatchingServicePort finds the service listen port that matches the given port specification.

--- a/pkg/resolvers/endpoints.go
+++ b/pkg/resolvers/endpoints.go
@@ -552,7 +552,7 @@ func (r *defaultEndpointsResolver) hasTargetPortBypass(svc *corev1.Service, matc
 		}
 		// Resolve the named port using the first matching container port, matching
 		// Kubernetes EndpointSlice controller behavior for svc resolution.
-		cp, found := firstNamedPort(pod, targetPortName, protocol)
+		cp, containerName, found := firstNamedPort(pod, targetPortName, protocol)
 		if !found {
 			continue
 		}
@@ -560,6 +560,7 @@ func (r *defaultEndpointsResolver) hasTargetPortBypass(svc *corev1.Service, matc
 			r.logger.Info("Named port resolves to disallowed container port",
 				"service", k8s.NamespacedName(svc),
 				"pod", k8s.NamespacedName(pod),
+				"container", containerName,
 				"portName", cp.Name,
 				"containerPort", cp.ContainerPort, "protocol", protocol)
 			return true
@@ -605,7 +606,7 @@ func isNumericPortAllowed(port int32, protocol corev1.Protocol, policyPorts []ne
 // firstNamedPort returns the first container port matching the given name and protocol in a pod.
 // This mirrors how Kubernetes EndpointSlice controller resolves named targetPorts — it picks the
 // first matching container port across all containers in declaration order.
-func firstNamedPort(pod *corev1.Pod, portName string, protocol corev1.Protocol) (corev1.ContainerPort, bool) {
+func firstNamedPort(pod *corev1.Pod, portName string, protocol corev1.Protocol) (corev1.ContainerPort, string, bool) {
 	for i := range pod.Spec.Containers {
 		for j := range pod.Spec.Containers[i].Ports {
 			cp := pod.Spec.Containers[i].Ports[j]
@@ -614,11 +615,11 @@ func firstNamedPort(pod *corev1.Pod, portName string, protocol corev1.Protocol) 
 				cpProto = corev1.ProtocolTCP
 			}
 			if cp.Name == portName && cpProto == protocol {
-				return cp, true
+				return cp, pod.Spec.Containers[i].Name, true
 			}
 		}
 	}
-	return corev1.ContainerPort{}, false
+	return corev1.ContainerPort{}, "", false
 }
 
 // getMatchingServicePort finds the service listen port that matches the given port specification.

--- a/pkg/resolvers/endpoints_test.go
+++ b/pkg/resolvers/endpoints_test.go
@@ -2135,6 +2135,39 @@ func TestEndpointsResolver_hasTargetPortBypass(t *testing.T) {
 			},
 			expected: true, // 8080 is outside range 80-100
 		},
+		{
+			name: "safe: multi-container pod — only first matching container port is checked",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "ns"},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "10.0.0.1",
+					Selector:  map[string]string{"app": "test"},
+					Ports: []corev1.ServicePort{
+						{Port: 80, TargetPort: intstr.FromString("http"), Protocol: corev1.ProtocolTCP},
+					},
+				},
+			},
+			matchedListenPort: 80,
+			protocol:          corev1.ProtocolTCP,
+			policyPorts: []networking.NetworkPolicyPort{
+				{Protocol: &protocolTCP, Port: &intOrStrPort80},
+				{Protocol: &protocolTCP, Port: &intOrStrPort8080},
+			},
+			pods: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "ns", Labels: map[string]string{"app": "test"}},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							// First container: http=8080 (this is what the Service resolves to)
+							{Name: "app", Ports: []corev1.ContainerPort{{Name: "http", ContainerPort: 8080, Protocol: corev1.ProtocolTCP}}},
+							// Second container: http=8090 (ignored by Service endpoint resolution)
+							{Name: "sidecar", Ports: []corev1.ContainerPort{{Name: "http", ContainerPort: 8090, Protocol: corev1.ProtocolTCP}}},
+						},
+					},
+				},
+			},
+			expected: false, // first container resolves http→8080 which is allowed; sidecar's 8090 is irrelevant
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
-->
**What type of PR is this?**
bugfix
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
follow up from https://github.com/aws/amazon-network-policy-controller-k8s/pull/223

when containers in a pod have same named port resolving to different numeric ports. Svc is resolved to first container matching as its Endpoint but NPC bypass logic was checking all containers named ports and resulting in un-necessary skip


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
- UT and manual test

**Automation added to e2e**:
<!--
List the e2e tests you added as part of this PR.
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new K8s API
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.