### PR TITLE
Migrate docker base images from AL2 to AL2023 (#216)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,8 +179,8 @@ $(MOCKGEN): $(LOCALBIN)
 
 GO_IMAGE_TAG=$(shell cat .go-version)
 BUILD_IMAGE ?= public.ecr.aws/docker/library/golang:$(GO_IMAGE_TAG)
-BASE_IMAGE ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:latest.2
-GO_RUNNER_IMAGE ?= public.ecr.aws/eks-distro-build-tooling/go-runner:v0.18.0-go-1.26-latest.al2
+BASE_IMAGE ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:latest-al23
+GO_RUNNER_IMAGE ?= public.ecr.aws/eks-distro-build-tooling/go-runner:v0.18.0-go-1.26-latest.al23
 .PHONY: docker-buildx
 docker-buildx: prepare-embed test
 	for platform in $(ARCHS); do \


### PR DESCRIPTION
Switches the default base image and go-runner image from AL2 to AL2023

**What type of PR is this?**

cleanup

**Which issue does this PR fix:**

Fixes #216

**What does this PR do / Why do we need it:**

Switches the default base image and go-runner image from AL2 to AL2023.

**Testing done on this change:**

Docker build (AL2023 base) - Pass
Unit tests - Pass
Cyclonus test - 81/81 passed

**Automation added to e2e:**

No new e2e tests needed — existing Cyclonus conformance suite validates network policy behavior end-to-end.

**Will this PR introduce any new dependencies?:**

No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?:**

No breaking changes. The AL2023 image was deployed to a running cluster and validated.

**Does this PR introduce any user-facing change?:**

No

```release-note
NONE
```