### PR TITLE
logging compute and crud latencies separately

### DIFF
--- a/pkg/policyendpoints/manager.go
+++ b/pkg/policyendpoints/manager.go
@@ -98,6 +98,8 @@ type policyEndpointsManager struct {
 }
 
 func (m *policyEndpointsManager) Reconcile(ctx context.Context, policy *networking.NetworkPolicy) error {
+	computeStart := time.Now()
+
 	ingressRules, egressRules, podSelectorEndpoints, err := m.endpointsResolver.Resolve(ctx, policy)
 	if err != nil {
 		return err
@@ -118,7 +120,10 @@ func (m *policyEndpointsManager) Reconcile(ctx context.Context, policy *networki
 	if err != nil {
 		return err
 	}
-	m.logger.Info("Got policy endpoints lists", "create", len(createList), "update", len(updateList), "delete", len(deleteList))
+
+	computeDuration := time.Since(computeStart)
+	crudStart := time.Now()
+
 	for i := range createList {
 		setLastChangeTriggerTime(&createList[i])
 		if err := m.k8sClient.Create(ctx, &createList[i]); err != nil {
@@ -150,6 +155,10 @@ func (m *policyEndpointsManager) Reconcile(ctx context.Context, policy *networki
 		m.logger.Info("Deleted policy endpoint", "id", k8s.NamespacedName(&policyEndpoint))
 	}
 
+	m.logger.Info("NP reconcile phase durations", "policy", policy.Name, "namespace", policy.Namespace,
+		"computeDuration", computeDuration.Seconds(), "crudDuration", time.Since(crudStart).Seconds(),
+		"create", len(createList), "update", len(updateList), "delete", len(deleteList))
+
 	return nil
 }
 
@@ -170,6 +179,8 @@ func (m *policyEndpointsManager) Cleanup(ctx context.Context, policy *networking
 }
 
 func (m *policyEndpointsManager) ReconcileANP(ctx context.Context, anp *policyinfo.ApplicationNetworkPolicy) error {
+	computeStart := time.Now()
+
 	ingressRules, egressRules, podSelectorEndpoints, err := m.anpEndpointsResolver.ResolveApplicationNetworkPolicy(ctx, anp)
 	if err != nil {
 		return err
@@ -190,7 +201,9 @@ func (m *policyEndpointsManager) ReconcileANP(ctx context.Context, anp *policyin
 	if err != nil {
 		return err
 	}
-	m.logger.Info("Got ANP policy endpoints lists", "create", len(createList), "update", len(updateList), "delete", len(deleteList))
+
+	computeDuration := time.Since(computeStart)
+	crudStart := time.Now()
 
 	for i := range createList {
 		setLastChangeTriggerTime(&createList[i])
@@ -222,6 +235,10 @@ func (m *policyEndpointsManager) ReconcileANP(ctx context.Context, anp *policyin
 		}
 		m.logger.Info("Deleted ANP policy endpoint", "id", k8s.NamespacedName(&policyEndpoint))
 	}
+
+	m.logger.Info("ANP reconcile phase durations", "policy", anp.Name, "namespace", anp.Namespace,
+		"computeDuration", computeDuration.Seconds(), "crudDuration", time.Since(crudStart).Seconds(),
+		"create", len(createList), "update", len(updateList), "delete", len(deleteList))
 
 	return nil
 }
@@ -732,6 +749,8 @@ func (m *policyEndpointsManager) computeApplicationNetworkPolicyEndpoints(anp *p
 }
 
 func (m *policyEndpointsManager) ReconcileCNP(ctx context.Context, cnp *policyinfo.ClusterNetworkPolicy) error {
+	computeStart := time.Now()
+
 	ingressRules, egressRules, podSelectorEndpoints, err := m.cnpEndpointsResolver.ResolveClusterNetworkPolicy(ctx, cnp)
 	if err != nil {
 		return err
@@ -751,7 +770,8 @@ func (m *policyEndpointsManager) ReconcileCNP(ctx context.Context, cnp *policyin
 		return err
 	}
 
-	m.logger.Info("Got cluster policy endpoints lists", "create", len(createList), "update", len(updateList), "delete", len(deleteList))
+	computeDuration := time.Since(computeStart)
+	crudStart := time.Now()
 
 	// Create, update, delete ClusterPolicyEndpoints
 	for i := range createList {
@@ -784,6 +804,10 @@ func (m *policyEndpointsManager) ReconcileCNP(ctx context.Context, cnp *policyin
 		}
 		m.logger.Info("Deleted cluster policy endpoint", "name", cpe.Name)
 	}
+
+	m.logger.Info("CNP reconcile phase durations", "policy", cnp.Name,
+		"computeDuration", computeDuration.Seconds(), "crudDuration", time.Since(crudStart).Seconds(),
+		"create", len(createList), "update", len(updateList), "delete", len(deleteList))
 
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
improvement in debugging

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add steps to reproduce and the controller logs**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

```
{"level":"info","ts":"2026-05-13T00:01:26Z","logger":"endpoints-manager","msg":"CNP reconcile phase durations","policy":"otel-ingress-telemetry","computeDuration":9.396917564,"crudDuration":1.288001401,"create":11,"update":12,"delete":0}
{"level":"info","ts":"2026-05-13T00:01:26Z","logger":"controllers.policy","msg":"Reconcile completed","resource":{"name":"otel-ingress-telemetry"},"duration":10.68506193,"success":true}
{"level":"info","ts":"2026-05-13T00:01:37Z","logger":"endpoints-manager","msg":"CNP reconcile phase durations","policy":"otel-ingress-telemetry","computeDuration":9.368827257,"crudDuration":1.350700505,"create":0,"update":23,"delete":0}
{"level":"info","ts":"2026-05-13T00:01:37Z","logger":"controllers.policy","msg":"Reconcile completed","resource":{"name":"otel-ingress-telemetry"},"duration":10.719582753,"success":true}
```

**Automation added to e2e**:
<!--
List the e2e tests you added as part of this PR.
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new K8s API
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.