### PR TITLE
fix ANP rule combine behavior using port key that prevented combining

### DIFF
--- a/pkg/policyendpoints/manager.go
+++ b/pkg/policyendpoints/manager.go
@@ -385,14 +385,18 @@ func (m *policyEndpointsManager) processANPPolicyEndpoints(pes []policyinfo.Poli
 	return newPEs
 }
 
-// combineANPRulesEndpoints handles both CIDR and FQDN endpoints
+// combineANPRulesEndpoints handles both CIDR and FQDN endpoints.
+// It combines entries with the same CIDR/DomainName+exceptions, merging their ports.
 func (m *policyEndpointsManager) combineANPRulesEndpoints(endpoints []policyinfo.EndpointInfo) []policyinfo.EndpointInfo {
 	combinedMap := make(map[string]policyinfo.EndpointInfo)
 	for _, ep := range endpoints {
-		key := m.getEndpointInfoKey(ep) // Uses hash that handles both CIDR and FQDN
+		key := getANPCombineKey(ep)
 		if existing, ok := combinedMap[key]; ok {
-			existing.Ports = append(existing.Ports, ep.Ports...)
-			existing.Except = append(existing.Except, ep.Except...)
+			if len(ep.Ports) == 0 || len(existing.Ports) == 0 {
+				existing.Ports = []policyinfo.Port{}
+			} else {
+				existing.Ports = deduplicatePorts(append(existing.Ports, ep.Ports...))
+			}
 			combinedMap[key] = existing
 		} else {
 			combinedMap[key] = ep
@@ -402,6 +406,28 @@ func (m *policyEndpointsManager) combineANPRulesEndpoints(endpoints []policyinfo
 		return maps.Values(combinedMap)
 	}
 	return nil
+}
+
+// getANPCombineKey creates a combining key from CIDR or DomainName and sorted exceptions,
+// excluding ports so that entries with the same network identity get merged.
+func getANPCombineKey(ep policyinfo.EndpointInfo) string {
+	var key string
+	if ep.DomainName != "" {
+		key = "fqdn|" + string(ep.DomainName) + "|"
+	} else {
+		key = "cidr|" + string(ep.CIDR) + "|"
+	}
+
+	sortedExcepts := make([]policyinfo.NetworkAddress, len(ep.Except))
+	copy(sortedExcepts, ep.Except)
+	sort.Slice(sortedExcepts, func(i, j int) bool {
+		return string(sortedExcepts[i]) < string(sortedExcepts[j])
+	})
+	for _, except := range sortedExcepts {
+		key += string(except) + "|"
+	}
+
+	return key
 }
 
 func (m *policyEndpointsManager) newPolicyEndpoint(metadata PolicyMetadata,

--- a/pkg/policyendpoints/manager.go
+++ b/pkg/policyendpoints/manager.go
@@ -332,17 +332,21 @@ func (m *policyEndpointsManager) processPolicyEndpoints(pes []policyinfo.PolicyE
 	return newPEs
 }
 
-// getCombineKey creates a combining key from CIDR and sorted exceptions
-func getCombineKey(iep policyinfo.EndpointInfo) string {
-	key := string(iep.CIDR) + "|"
+// getCombineKey creates a combining key from CIDR or DomainName and sorted exceptions,
+// excluding ports so that entries with the same network identity get merged.
+func getCombineKey(ep policyinfo.EndpointInfo) string {
+	var key string
+	if ep.DomainName != "" {
+		key = "fqdn|" + string(ep.DomainName) + "|"
+	} else {
+		key = "cidr|" + string(ep.CIDR) + "|"
+	}
 
-	// Sort exceptions for order-independence
-	sortedExcepts := make([]policyinfo.NetworkAddress, len(iep.Except))
-	copy(sortedExcepts, iep.Except)
+	sortedExcepts := make([]policyinfo.NetworkAddress, len(ep.Except))
+	copy(sortedExcepts, ep.Except)
 	sort.Slice(sortedExcepts, func(i, j int) bool {
 		return string(sortedExcepts[i]) < string(sortedExcepts[j])
 	})
-
 	for _, except := range sortedExcepts {
 		key += string(except) + "|"
 	}
@@ -378,56 +382,11 @@ func combineRulesEndpoints(ingressEndpoints []policyinfo.EndpointInfo) []policyi
 func (m *policyEndpointsManager) processANPPolicyEndpoints(pes []policyinfo.PolicyEndpoint) []policyinfo.PolicyEndpoint {
 	var newPEs []policyinfo.PolicyEndpoint
 	for _, pe := range pes {
-		pe.Spec.Ingress = m.combineANPRulesEndpoints(pe.Spec.Ingress)
-		pe.Spec.Egress = m.combineANPRulesEndpoints(pe.Spec.Egress)
+		pe.Spec.Ingress = combineRulesEndpoints(pe.Spec.Ingress)
+		pe.Spec.Egress = combineRulesEndpoints(pe.Spec.Egress)
 		newPEs = append(newPEs, pe)
 	}
 	return newPEs
-}
-
-// combineANPRulesEndpoints handles both CIDR and FQDN endpoints.
-// It combines entries with the same CIDR/DomainName+exceptions, merging their ports.
-func (m *policyEndpointsManager) combineANPRulesEndpoints(endpoints []policyinfo.EndpointInfo) []policyinfo.EndpointInfo {
-	combinedMap := make(map[string]policyinfo.EndpointInfo)
-	for _, ep := range endpoints {
-		key := getANPCombineKey(ep)
-		if existing, ok := combinedMap[key]; ok {
-			if len(ep.Ports) == 0 || len(existing.Ports) == 0 {
-				existing.Ports = []policyinfo.Port{}
-			} else {
-				existing.Ports = deduplicatePorts(append(existing.Ports, ep.Ports...))
-			}
-			combinedMap[key] = existing
-		} else {
-			combinedMap[key] = ep
-		}
-	}
-	if len(combinedMap) > 0 {
-		return maps.Values(combinedMap)
-	}
-	return nil
-}
-
-// getANPCombineKey creates a combining key from CIDR or DomainName and sorted exceptions,
-// excluding ports so that entries with the same network identity get merged.
-func getANPCombineKey(ep policyinfo.EndpointInfo) string {
-	var key string
-	if ep.DomainName != "" {
-		key = "fqdn|" + string(ep.DomainName) + "|"
-	} else {
-		key = "cidr|" + string(ep.CIDR) + "|"
-	}
-
-	sortedExcepts := make([]policyinfo.NetworkAddress, len(ep.Except))
-	copy(sortedExcepts, ep.Except)
-	sort.Slice(sortedExcepts, func(i, j int) bool {
-		return string(sortedExcepts[i]) < string(sortedExcepts[j])
-	})
-	for _, except := range sortedExcepts {
-		key += string(except) + "|"
-	}
-
-	return key
 }
 
 func (m *policyEndpointsManager) newPolicyEndpoint(metadata PolicyMetadata,

--- a/pkg/policyendpoints/manager_test.go
+++ b/pkg/policyendpoints/manager_test.go
@@ -937,33 +937,292 @@ func Test_processANPPolicyEndpoints(t *testing.T) {
 	}
 
 	port443 := int32(443)
+	port80 := int32(80)
 	pTCP := corev1.ProtocolTCP
 
-	pes := m.processANPPolicyEndpoints([]policyinfo.PolicyEndpoint{
-		{
-			Spec: policyinfo.PolicyEndpointSpec{
-				Egress: []policyinfo.EndpointInfo{
-					{
-						DomainName: "example.com",
-						Ports: []policyinfo.Port{
-							{Port: &port443, Protocol: &pTCP},
+	t.Run("same FQDN with different ports combines and deduplicates", func(t *testing.T) {
+		pes := m.processANPPolicyEndpoints([]policyinfo.PolicyEndpoint{
+			{
+				Spec: policyinfo.PolicyEndpointSpec{
+					Egress: []policyinfo.EndpointInfo{
+						{
+							DomainName: "example.com",
+							Ports: []policyinfo.Port{
+								{Port: &port443, Protocol: &pTCP},
+							},
 						},
-					},
-					{
-						DomainName: "example.com",
-						Ports: []policyinfo.Port{
-							{Port: &port443, Protocol: &pTCP},
+						{
+							DomainName: "example.com",
+							Ports: []policyinfo.Port{
+								{Port: &port80, Protocol: &pTCP},
+							},
 						},
 					},
 				},
 			},
-		},
+		})
+
+		assert.Equal(t, 1, len(pes))
+		assert.Equal(t, 1, len(pes[0].Spec.Egress))
+		assert.Equal(t, policyinfo.DomainName("example.com"), pes[0].Spec.Egress[0].DomainName)
+		assert.Equal(t, 2, len(pes[0].Spec.Egress[0].Ports))
 	})
 
-	assert.Equal(t, 1, len(pes))
-	assert.Equal(t, 1, len(pes[0].Spec.Egress))
-	assert.Equal(t, policyinfo.DomainName("example.com"), pes[0].Spec.Egress[0].DomainName)
-	assert.Equal(t, 2, len(pes[0].Spec.Egress[0].Ports))
+	t.Run("duplicate entries are deduplicated to single port", func(t *testing.T) {
+		pes := m.processANPPolicyEndpoints([]policyinfo.PolicyEndpoint{
+			{
+				Spec: policyinfo.PolicyEndpointSpec{
+					Egress: []policyinfo.EndpointInfo{
+						{
+							DomainName: "example.com",
+							Ports: []policyinfo.Port{
+								{Port: &port443, Protocol: &pTCP},
+							},
+						},
+						{
+							DomainName: "example.com",
+							Ports: []policyinfo.Port{
+								{Port: &port443, Protocol: &pTCP},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		assert.Equal(t, 1, len(pes))
+		assert.Equal(t, 1, len(pes[0].Spec.Egress))
+		assert.Equal(t, policyinfo.DomainName("example.com"), pes[0].Spec.Egress[0].DomainName)
+		assert.Equal(t, 1, len(pes[0].Spec.Egress[0].Ports), "Duplicate ports should be deduplicated")
+	})
+}
+
+func Test_combineANPRulesEndpoints(t *testing.T) {
+	m := &policyEndpointsManager{
+		logger: zap.New(),
+	}
+
+	port80 := int32(80)
+	port443 := int32(443)
+	port8080 := int32(8080)
+	pTCP := corev1.ProtocolTCP
+	pUDP := corev1.ProtocolUDP
+
+	t.Run("same FQDN different ports should combine", func(t *testing.T) {
+		endpoints := []policyinfo.EndpointInfo{
+			{
+				DomainName: "example.com",
+				Ports:      []policyinfo.Port{{Port: &port80, Protocol: &pTCP}},
+			},
+			{
+				DomainName: "example.com",
+				Ports:      []policyinfo.Port{{Port: &port443, Protocol: &pTCP}},
+			},
+		}
+
+		result := m.combineANPRulesEndpoints(endpoints)
+
+		assert.Equal(t, 1, len(result), "Same FQDN with different ports should combine into one entry")
+		assert.Equal(t, policyinfo.DomainName("example.com"), result[0].DomainName)
+		assert.Equal(t, 2, len(result[0].Ports), "Both ports should be present after combining")
+	})
+
+	t.Run("same CIDR different ports should combine", func(t *testing.T) {
+		endpoints := []policyinfo.EndpointInfo{
+			{
+				CIDR:  "10.0.0.0/8",
+				Ports: []policyinfo.Port{{Port: &port80, Protocol: &pTCP}},
+			},
+			{
+				CIDR:  "10.0.0.0/8",
+				Ports: []policyinfo.Port{{Port: &port443, Protocol: &pTCP}},
+			},
+			{
+				CIDR:  "10.0.0.0/8",
+				Ports: []policyinfo.Port{{Port: &port8080, Protocol: &pTCP}},
+			},
+		}
+
+		result := m.combineANPRulesEndpoints(endpoints)
+
+		assert.Equal(t, 1, len(result), "Same CIDR with different ports should combine into one entry")
+		assert.Equal(t, policyinfo.NetworkAddress("10.0.0.0/8"), result[0].CIDR)
+		assert.Equal(t, 3, len(result[0].Ports), "All three ports should be present after combining")
+	})
+
+	t.Run("same FQDN all-ports entry wins", func(t *testing.T) {
+		endpoints := []policyinfo.EndpointInfo{
+			{
+				DomainName: "example.com",
+				Ports:      []policyinfo.Port{{Port: &port443, Protocol: &pTCP}},
+			},
+			{
+				DomainName: "example.com",
+				Ports:      []policyinfo.Port{}, // empty = all ports
+			},
+		}
+
+		result := m.combineANPRulesEndpoints(endpoints)
+
+		assert.Equal(t, 1, len(result), "Same FQDN should combine")
+		assert.Equal(t, 0, len(result[0].Ports), "All-ports (empty) should take precedence")
+	})
+
+	t.Run("same CIDR with exceptions different ports should combine", func(t *testing.T) {
+		endpoints := []policyinfo.EndpointInfo{
+			{
+				CIDR:   "10.0.0.0/8",
+				Except: []policyinfo.NetworkAddress{"10.1.0.0/16"},
+				Ports:  []policyinfo.Port{{Port: &port80, Protocol: &pTCP}},
+			},
+			{
+				CIDR:   "10.0.0.0/8",
+				Except: []policyinfo.NetworkAddress{"10.1.0.0/16"},
+				Ports:  []policyinfo.Port{{Port: &port443, Protocol: &pTCP}},
+			},
+		}
+
+		result := m.combineANPRulesEndpoints(endpoints)
+
+		assert.Equal(t, 1, len(result), "Same CIDR+exceptions with different ports should combine")
+		assert.Equal(t, 2, len(result[0].Ports))
+	})
+
+	t.Run("different CIDRs should not combine", func(t *testing.T) {
+		endpoints := []policyinfo.EndpointInfo{
+			{
+				CIDR:  "10.0.0.0/8",
+				Ports: []policyinfo.Port{{Port: &port80, Protocol: &pTCP}},
+			},
+			{
+				CIDR:  "172.16.0.0/12",
+				Ports: []policyinfo.Port{{Port: &port80, Protocol: &pTCP}},
+			},
+		}
+
+		result := m.combineANPRulesEndpoints(endpoints)
+
+		assert.Equal(t, 2, len(result), "Different CIDRs should remain separate")
+	})
+
+	t.Run("different FQDNs should not combine", func(t *testing.T) {
+		endpoints := []policyinfo.EndpointInfo{
+			{
+				DomainName: "example.com",
+				Ports:      []policyinfo.Port{{Port: &port443, Protocol: &pTCP}},
+			},
+			{
+				DomainName: "other.com",
+				Ports:      []policyinfo.Port{{Port: &port443, Protocol: &pTCP}},
+			},
+		}
+
+		result := m.combineANPRulesEndpoints(endpoints)
+
+		assert.Equal(t, 2, len(result), "Different FQDNs should remain separate")
+	})
+
+	t.Run("same CIDR different exceptions should not combine", func(t *testing.T) {
+		endpoints := []policyinfo.EndpointInfo{
+			{
+				CIDR:   "10.0.0.0/8",
+				Except: []policyinfo.NetworkAddress{"10.1.0.0/16"},
+				Ports:  []policyinfo.Port{{Port: &port80, Protocol: &pTCP}},
+			},
+			{
+				CIDR:   "10.0.0.0/8",
+				Except: []policyinfo.NetworkAddress{"10.2.0.0/16"},
+				Ports:  []policyinfo.Port{{Port: &port80, Protocol: &pTCP}},
+			},
+		}
+
+		result := m.combineANPRulesEndpoints(endpoints)
+
+		assert.Equal(t, 2, len(result), "Same CIDR with different exceptions should remain separate")
+	})
+
+	t.Run("duplicate ports should be deduplicated", func(t *testing.T) {
+		endpoints := []policyinfo.EndpointInfo{
+			{
+				DomainName: "example.com",
+				Ports:      []policyinfo.Port{{Port: &port80, Protocol: &pTCP}},
+			},
+			{
+				DomainName: "example.com",
+				Ports:      []policyinfo.Port{{Port: &port80, Protocol: &pTCP}},
+			},
+		}
+
+		result := m.combineANPRulesEndpoints(endpoints)
+
+		assert.Equal(t, 1, len(result))
+		assert.Equal(t, 1, len(result[0].Ports), "Duplicate ports should be deduplicated")
+	})
+
+	t.Run("same CIDR with exceptions in different order should combine", func(t *testing.T) {
+		endpoints := []policyinfo.EndpointInfo{
+			{
+				CIDR:   "10.0.0.0/8",
+				Except: []policyinfo.NetworkAddress{"192.168.0.0/16", "172.16.0.0/12"},
+				Ports:  []policyinfo.Port{{Port: &port80, Protocol: &pTCP}},
+			},
+			{
+				CIDR:   "10.0.0.0/8",
+				Except: []policyinfo.NetworkAddress{"172.16.0.0/12", "192.168.0.0/16"},
+				Ports:  []policyinfo.Port{{Port: &port443, Protocol: &pTCP}},
+			},
+		}
+
+		result := m.combineANPRulesEndpoints(endpoints)
+
+		assert.Equal(t, 1, len(result), "Same exceptions in different order should combine")
+		assert.Equal(t, 2, len(result[0].Ports))
+	})
+
+	t.Run("mixed FQDN and CIDR should not combine", func(t *testing.T) {
+		endpoints := []policyinfo.EndpointInfo{
+			{
+				DomainName: "10.0.0.0/8",
+				Ports:      []policyinfo.Port{{Port: &port80, Protocol: &pTCP}},
+			},
+			{
+				CIDR:  "10.0.0.0/8",
+				Ports: []policyinfo.Port{{Port: &port80, Protocol: &pTCP}},
+			},
+		}
+
+		result := m.combineANPRulesEndpoints(endpoints)
+
+		assert.Equal(t, 2, len(result), "FQDN and CIDR entries should not combine even if string matches")
+	})
+
+	t.Run("parity with NP combineRulesEndpoints for CIDR case", func(t *testing.T) {
+		// This test verifies ANP combining produces the same result as NP combining
+		// for CIDR-based endpoints (the common case)
+		endpoints := []policyinfo.EndpointInfo{
+			{
+				CIDR:  "10.0.0.0/8",
+				Ports: []policyinfo.Port{{Port: &port80, Protocol: &pTCP}},
+			},
+			{
+				CIDR:  "10.0.0.0/8",
+				Ports: []policyinfo.Port{{Port: &port443, Protocol: &pTCP}},
+			},
+			{
+				CIDR:  "10.0.0.0/8",
+				Ports: []policyinfo.Port{{Protocol: &pUDP}},
+			},
+		}
+
+		npResult := combineRulesEndpoints(endpoints)
+		anpResult := m.combineANPRulesEndpoints(endpoints)
+
+		assert.Equal(t, len(npResult), len(anpResult),
+			"ANP and NP combining should produce same number of entries for CIDR endpoints")
+		assert.Equal(t, 1, len(anpResult))
+		assert.Equal(t, 3, len(anpResult[0].Ports),
+			"ANP should combine ports the same way NP does")
+	})
 }
 
 func Test_getEndpointInfoKey(t *testing.T) {

--- a/pkg/policyendpoints/manager_test.go
+++ b/pkg/policyendpoints/manager_test.go
@@ -997,11 +997,7 @@ func Test_processANPPolicyEndpoints(t *testing.T) {
 	})
 }
 
-func Test_combineANPRulesEndpoints(t *testing.T) {
-	m := &policyEndpointsManager{
-		logger: zap.New(),
-	}
-
+func Test_combineRulesEndpoints(t *testing.T) {
 	port80 := int32(80)
 	port443 := int32(443)
 	port8080 := int32(8080)
@@ -1020,7 +1016,7 @@ func Test_combineANPRulesEndpoints(t *testing.T) {
 			},
 		}
 
-		result := m.combineANPRulesEndpoints(endpoints)
+		result := combineRulesEndpoints(endpoints)
 
 		assert.Equal(t, 1, len(result), "Same FQDN with different ports should combine into one entry")
 		assert.Equal(t, policyinfo.DomainName("example.com"), result[0].DomainName)
@@ -1043,7 +1039,7 @@ func Test_combineANPRulesEndpoints(t *testing.T) {
 			},
 		}
 
-		result := m.combineANPRulesEndpoints(endpoints)
+		result := combineRulesEndpoints(endpoints)
 
 		assert.Equal(t, 1, len(result), "Same CIDR with different ports should combine into one entry")
 		assert.Equal(t, policyinfo.NetworkAddress("10.0.0.0/8"), result[0].CIDR)
@@ -1062,7 +1058,7 @@ func Test_combineANPRulesEndpoints(t *testing.T) {
 			},
 		}
 
-		result := m.combineANPRulesEndpoints(endpoints)
+		result := combineRulesEndpoints(endpoints)
 
 		assert.Equal(t, 1, len(result), "Same FQDN should combine")
 		assert.Equal(t, 0, len(result[0].Ports), "All-ports (empty) should take precedence")
@@ -1082,7 +1078,7 @@ func Test_combineANPRulesEndpoints(t *testing.T) {
 			},
 		}
 
-		result := m.combineANPRulesEndpoints(endpoints)
+		result := combineRulesEndpoints(endpoints)
 
 		assert.Equal(t, 1, len(result), "Same CIDR+exceptions with different ports should combine")
 		assert.Equal(t, 2, len(result[0].Ports))
@@ -1100,7 +1096,7 @@ func Test_combineANPRulesEndpoints(t *testing.T) {
 			},
 		}
 
-		result := m.combineANPRulesEndpoints(endpoints)
+		result := combineRulesEndpoints(endpoints)
 
 		assert.Equal(t, 2, len(result), "Different CIDRs should remain separate")
 	})
@@ -1117,7 +1113,7 @@ func Test_combineANPRulesEndpoints(t *testing.T) {
 			},
 		}
 
-		result := m.combineANPRulesEndpoints(endpoints)
+		result := combineRulesEndpoints(endpoints)
 
 		assert.Equal(t, 2, len(result), "Different FQDNs should remain separate")
 	})
@@ -1136,7 +1132,7 @@ func Test_combineANPRulesEndpoints(t *testing.T) {
 			},
 		}
 
-		result := m.combineANPRulesEndpoints(endpoints)
+		result := combineRulesEndpoints(endpoints)
 
 		assert.Equal(t, 2, len(result), "Same CIDR with different exceptions should remain separate")
 	})
@@ -1153,7 +1149,7 @@ func Test_combineANPRulesEndpoints(t *testing.T) {
 			},
 		}
 
-		result := m.combineANPRulesEndpoints(endpoints)
+		result := combineRulesEndpoints(endpoints)
 
 		assert.Equal(t, 1, len(result))
 		assert.Equal(t, 1, len(result[0].Ports), "Duplicate ports should be deduplicated")
@@ -1173,7 +1169,7 @@ func Test_combineANPRulesEndpoints(t *testing.T) {
 			},
 		}
 
-		result := m.combineANPRulesEndpoints(endpoints)
+		result := combineRulesEndpoints(endpoints)
 
 		assert.Equal(t, 1, len(result), "Same exceptions in different order should combine")
 		assert.Equal(t, 2, len(result[0].Ports))
@@ -1191,14 +1187,12 @@ func Test_combineANPRulesEndpoints(t *testing.T) {
 			},
 		}
 
-		result := m.combineANPRulesEndpoints(endpoints)
+		result := combineRulesEndpoints(endpoints)
 
 		assert.Equal(t, 2, len(result), "FQDN and CIDR entries should not combine even if string matches")
 	})
 
-	t.Run("parity with NP combineRulesEndpoints for CIDR case", func(t *testing.T) {
-		// This test verifies ANP combining produces the same result as NP combining
-		// for CIDR-based endpoints (the common case)
+	t.Run("CIDR entries with multiple ports and protocols combine correctly", func(t *testing.T) {
 		endpoints := []policyinfo.EndpointInfo{
 			{
 				CIDR:  "10.0.0.0/8",
@@ -1214,14 +1208,11 @@ func Test_combineANPRulesEndpoints(t *testing.T) {
 			},
 		}
 
-		npResult := combineRulesEndpoints(endpoints)
-		anpResult := m.combineANPRulesEndpoints(endpoints)
+		result := combineRulesEndpoints(endpoints)
 
-		assert.Equal(t, len(npResult), len(anpResult),
-			"ANP and NP combining should produce same number of entries for CIDR endpoints")
-		assert.Equal(t, 1, len(anpResult))
-		assert.Equal(t, 3, len(anpResult[0].Ports),
-			"ANP should combine ports the same way NP does")
+		assert.Equal(t, 1, len(result))
+		assert.Equal(t, 3, len(result[0].Ports),
+			"All ports across protocols should be combined")
 	})
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
  1. Ensure you have added the unit tests for your changes.
  2. Ensure you have included output of manual testing done in the Testing section.
  3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
  4. Ensure your change works on existing clusters after upgrade.
  -->
  **What type of PR is this?**

  <!--
  Add one of the following:
  bug
  cleanup
  documentation
  feature
  -->
  bug

  **Which issue does this PR fix**:

  `combineANPRulesEndpoints` is effectively a no-op and it never combines entries because the map key includes ports.

  **What does this PR do / Why do we need it**:

  - `combineANPRulesEndpoints` used `getEndpointInfoKey` (which hashes CIDR/FQDN + exceptions + ports) as the combining key. Since ports are part of the key, two entries with the same domain/CIDR but different ports produce different keys and never match.
  - This PR extends `getCombineKey` to handle DomainName (FQDN) entries with a type prefix (fqdn| / cidr|), eliminating the need for a separate ANP-specific function. `processANPPolicyEndpoints` now calls `combineRulesEndpoints` directly, unifying the combining logic for both NP and ANP paths with proper "all-ports wins" semantics and port deduplication.

**Before fix** — redundant entries emitted to PolicyEndpoint:
```
  egress:
  - domainName: example.com
  ports: [{port: 80, protocol: TCP}]
  - domainName: example.com
  ports: [{port: 443, protocol: TCP}]
```

  **After fix** — correctly consolidated:
```
  egress:
  - domainName: example.com
  ports: [{port: 80, protocol: TCP}, {port: 443, protocol: TCP}]
```

  **All-ports-wins case before fix** — both entries emitted:
```  
egress:
  - domainName: example.com
  ports: [{port: 443, protocol: TCP}]
  - domainName: example.com
  ports: []
```
  **After fix** — all-ports entry subsumes specific port:
``` 
 egress:
  - domainName: example.com
  ports: []
```
  **If an issue # is not available please add steps to reproduce and the controller logs**:

  1. Create an ANP with multiple egress rules targeting the same FQDN on different ports
  2. Observe the resulting PolicyEndpoint has duplicate entries for the same domain instead of one consolidated entry

  **Testing done on this change**:
  <!--
  output of manual testing/integration tests results and also attach logs
  showing the fix being resolved
  -->
1. Added UTs
```
 $ go test ./pkg/policyendpoints/ -run "Test_combineRulesEndpoints$" -v
  === RUN   Test_combineRulesEndpoints
  === RUN   Test_combineRulesEndpoints/same_FQDN_different_ports_should_combine
  === RUN   Test_combineRulesEndpoints/same_CIDR_different_ports_should_combine
  === RUN   Test_combineRulesEndpoints/same_FQDN_all-ports_entry_wins
  === RUN   Test_combineRulesEndpoints/same_CIDR_with_exceptions_different_ports_should_combine
  === RUN   Test_combineRulesEndpoints/different_CIDRs_should_not_combine
  === RUN   Test_combineRulesEndpoints/different_FQDNs_should_not_combine
  === RUN   Test_combineRulesEndpoints/same_CIDR_different_exceptions_should_not_combine
  === RUN   Test_combineRulesEndpoints/duplicate_ports_should_be_deduplicated
  === RUN   Test_combineRulesEndpoints/same_CIDR_with_exceptions_in_different_order_should_combine
  === RUN   Test_combineRulesEndpoints/mixed_FQDN_and_CIDR_should_not_combine
  === RUN   Test_combineRulesEndpoints/CIDR_entries_with_multiple_ports_and_protocols_combine_correctly
  --- PASS: Test_combineRulesEndpoints (0.00s)

  $ go test ./...
  ok    github.com/aws/amazon-network-policy-controller-k8s/api/v1alpha1
  ok    github.com/aws/amazon-network-policy-controller-k8s/internal/controllers
  ok    github.com/aws/amazon-network-policy-controller-k8s/pkg/config
  ok    github.com/aws/amazon-network-policy-controller-k8s/pkg/crd
  ok    github.com/aws/amazon-network-policy-controller-k8s/pkg/equality
  ok    github.com/aws/amazon-network-policy-controller-k8s/pkg/k8s
  ok    github.com/aws/amazon-network-policy-controller-k8s/pkg/metrics
  ok    github.com/aws/amazon-network-policy-controller-k8s/pkg/policyendpoints
  ok    github.com/aws/amazon-network-policy-controller-k8s/pkg/resolvers
```
2. cyclonus tests passed for regression guard
```
  $ python3 scripts/lib/verify_test_results.py -f scripts/results.log -ip IPv4
  ...
  Test Number:108 | Step 1 | Passed -> Correct:81 Expected:81
  Test Number:109 | Step 1 | Passed -> Correct:81 Expected:81
  ...
  Test Number:108 | Step 1 | Passed -> Correct:81 Expected:81
  Test Number:109 | Step 1 | Passed -> Correct:81 Expected:81
  Test Number:110 | Step 1 | Passed -> Correct:81 Expected:81
  Test Number:111 | Step 1 | Passed -> Correct:80 Expected:80
  Test Number:112 | Step 1 | Passed -> Correct:80 Expected:80

  Exit code: 0 (all 112 test cases passed)
```
  **Automation added to e2e**:
  <!--
  List the e2e tests you added as part of this PR.
  If no, create an issue with enhancement/testing label
  -->

  **Will this PR introduce any new dependencies?**:
  <!--
  e.g. new K8s API
  -->
  No

  **Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

Cyclonus tests passed as mentioned above. NPA e2e tests also passed
```
  Ran 11 of 11 Specs in 488.483 seconds — SUCCESS! -- 11 Passed | 0 Failed  (ApplicationNetworkPolicy)
  Ran 24 of 24 Specs in 794.839 seconds — SUCCESS! -- 24 Passed | 0 Failed  (ClusterNetworkPolicy)
  Ran 10 of 10 Specs in 445.291 seconds — SUCCESS! -- 10 Passed | 0 Failed  (MixNetworkPolicy)
  Ran 11 of 11 Specs in 1157.236 seconds — SUCCESS! -- 11 Passed | 0 Failed (NetworkPolicy)
```

  **Does this PR introduce any user-facing change?**:
  <!--
  If yes, a release note update is required:
  Enter your extended release note in the block below. If the PR requires additional actions
  from users switching to the new release, include the string "action required".
  -->

  ```release-note
  Fix ApplicationNetworkPolicy endpoint combining to correctly consolidate entries with the same CIDR/DomainName but different ports, reducing redundant entries in PolicyEndpoint objects.

  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
  ```