### PR TITLE
Eliminate redundant namespace loop in CNP resolver

### DIFF
--- a/pkg/resolvers/clusternetworkpolicy_resolver.go
+++ b/pkg/resolvers/clusternetworkpolicy_resolver.go
@@ -162,17 +162,6 @@ func (r *clusterNetworkPolicyEndpointsResolver) resolvePodEndpointsFromSubject(c
 	return []policyinfo.PodEndpoint{}, nil
 }
 
-func (r *clusterNetworkPolicyEndpointsResolver) resolveTargetNamespaces(ctx context.Context, nsSelector *metav1.LabelSelector, podNSSelector *metav1.LabelSelector) ([]string, error) {
-	if nsSelector != nil {
-		// Handle namespace selector
-		return r.resolveNamespacesBySelector(ctx, *nsSelector)
-	} else if podNSSelector != nil {
-		// Handle pods selector - get namespaces from NamespaceSelector
-		return r.resolveNamespacesBySelector(ctx, *podNSSelector)
-	}
-	return nil, nil
-}
-
 func (r *clusterNetworkPolicyEndpointsResolver) resolveNamespacesBySelector(ctx context.Context, nsSelector metav1.LabelSelector) ([]string, error) {
 	// Empty selector {} means all namespaces
 	if len(nsSelector.MatchLabels) == 0 && len(nsSelector.MatchExpressions) == 0 {
@@ -256,15 +245,33 @@ func (r *clusterNetworkPolicyEndpointsResolver) convertCNPPortsToEndpointPorts(c
 	return ports
 }
 
+func hasNamedCNPPorts(cnpPorts *[]policyinfo.ClusterNetworkPolicyPort) bool {
+	if cnpPorts == nil {
+		return false
+	}
+
+	for _, cnpPort := range *cnpPorts {
+		if cnpPort.NamedPort != nil {
+			return true
+		}
+	}
+	return false
+}
+
 func (r *clusterNetworkPolicyEndpointsResolver) resolveCNPEgressRules(ctx context.Context, cnp *policyinfo.ClusterNetworkPolicy) ([]policyinfo.ClusterEndpointInfo, error) {
 	var endpointInfos []policyinfo.ClusterEndpointInfo
+
+	subjectNamespace, err := r.getSubjectNamespace(ctx, cnp)
+	if err != nil {
+		return nil, fmt.Errorf("err in resolving CNP egress rules %w", err)
+	}
 
 	for _, rule := range cnp.Spec.Egress {
 		for _, peer := range rule.To {
 			// Handle each peer type exclusively
 			if len(peer.Networks) > 0 {
-				// CIDR peer - convert to NP and resolve (namespace doesn't affect CIDR resolution)
-				tempNP := r.convertSingleCNPEgressRuleToNP(cnp, rule, "default")
+				// CIDR peer - namespace is irrelevant for CIDR resolution
+				tempNP := r.convertSingleCNPEgressRuleToNP(cnp, rule, subjectNamespace)
 				_, cidrEgressEndpoints, _, err := r.baseResolver.Resolve(ctx, tempNP)
 				if err != nil {
 					return nil, err
@@ -278,30 +285,18 @@ func (r *clusterNetworkPolicyEndpointsResolver) resolveCNPEgressRules(ctx contex
 					})
 				}
 			} else if peer.Namespaces != nil || peer.Pods != nil {
-				// Namespace or Pod peer - resolve target namespaces
-				var podNSSelector *metav1.LabelSelector
-				if peer.Pods != nil {
-					podNSSelector = &peer.Pods.NamespaceSelector
-				}
-				targetNamespaces, err := r.resolveTargetNamespaces(ctx, peer.Namespaces, podNSSelector)
+				tempNP := r.convertSingleCNPEgressRuleToNP(cnp, rule, subjectNamespace)
+				_, egressEndpoints, _, err := r.baseResolver.Resolve(ctx, tempNP)
 				if err != nil {
 					return nil, err
 				}
 
-				for _, ns := range targetNamespaces {
-					tempNP := r.convertSingleCNPEgressRuleToNP(cnp, rule, ns)
-					_, cidrEgressEndpoints, _, err := r.baseResolver.Resolve(ctx, tempNP)
-					if err != nil {
-						return nil, err
-					}
-
-					for _, endpoint := range cidrEgressEndpoints {
-						endpointInfos = append(endpointInfos, policyinfo.ClusterEndpointInfo{
-							CIDR:   endpoint.CIDR,
-							Ports:  endpoint.Ports,
-							Action: rule.Action,
-						})
-					}
+				for _, endpoint := range egressEndpoints {
+					endpointInfos = append(endpointInfos, policyinfo.ClusterEndpointInfo{
+						CIDR:   endpoint.CIDR,
+						Ports:  endpoint.Ports,
+						Action: rule.Action,
+					})
 				}
 			} else if len(peer.DomainNames) > 0 {
 				// Domain name peer - handle directly
@@ -323,6 +318,19 @@ func (r *clusterNetworkPolicyEndpointsResolver) resolveCNPEgressRules(ctx contex
 	return r.mergeClusterEndpointInfo(endpointInfos), nil
 }
 
+// convertSingleCNPIngressRuleToNP builds a temporary NetworkPolicy that wraps a
+// single CNP ingress rule so it can be fed to baseResolver.Resolve(), which
+// only understands the upstream NetworkPolicy schema.
+//
+// Each CNP peer is mapped to an NP peer with an explicit NamespaceSelector
+// (Namespaces.* or Pods.NamespaceSelector). Because every NP peer carries an
+// explicit NamespaceSelector, baseResolver.resolvePeerNamespaces resolves peer
+// namespaces from the selector itself and ignores the temp NP's namespace —
+// so a single Resolve() call returns endpoints across all matching namespaces.
+//
+// The `namespace` argument is used only for named-port resolution against the
+// policy's destination pods (subject pods); callers pass the CNP's subject
+// namespace.
 func (r *clusterNetworkPolicyEndpointsResolver) convertSingleCNPIngressRuleToNP(cnp *policyinfo.ClusterNetworkPolicy, rule policyinfo.ClusterNetworkPolicyIngressRule, namespace string) *networking.NetworkPolicy {
 	// Convert CNP ingress peers to NP peers
 	var npPeers []networking.NetworkPolicyPeer
@@ -356,6 +364,18 @@ func (r *clusterNetworkPolicyEndpointsResolver) convertSingleCNPIngressRuleToNP(
 	}
 }
 
+// convertSingleCNPEgressRuleToNP builds a temporary NetworkPolicy that wraps a
+// single CNP egress rule so it can be fed to baseResolver.Resolve().
+//
+// Networks (CIDRs) become NP IPBlock peers (one per CIDR). Namespace/Pod peers
+// map to NP peers with explicit NamespaceSelector — baseResolver resolves all
+// matching namespaces internally, so a single Resolve() call covers the full
+// peer set without an outer namespace loop. DomainNames are skipped here and
+// emitted directly by the caller.
+//
+// The `namespace` argument is unused by baseResolver for egress in practice:
+// egress named ports resolve against destination (peer) pods per-peer, and
+// CIDR peers are namespace-agnostic.
 func (r *clusterNetworkPolicyEndpointsResolver) convertSingleCNPEgressRuleToNP(cnp *policyinfo.ClusterNetworkPolicy, rule policyinfo.ClusterNetworkPolicyEgressRule, namespace string) *networking.NetworkPolicy {
 	// Convert only CIDR/namespace/pod peers, skip domainNames
 	var npPeers []networking.NetworkPolicyPeer
@@ -402,38 +422,65 @@ func (r *clusterNetworkPolicyEndpointsResolver) convertSingleCNPEgressRuleToNP(c
 	}
 }
 func (r *clusterNetworkPolicyEndpointsResolver) resolveCNPIngressRules(ctx context.Context, cnp *policyinfo.ClusterNetworkPolicy) ([]policyinfo.ClusterEndpointInfo, error) {
+	// Determine subject namespace for named port resolution.
+	// Named ports resolve against the policy's destination pods (subject pods).
+	subjectNamespace, err := r.getSubjectNamespace(ctx, cnp)
+	if err != nil {
+		return nil, fmt.Errorf("err in resolving CNP ingress rules %w", err)
+	}
+
 	var allIngressRules []policyinfo.ClusterEndpointInfo
-
 	for _, rule := range cnp.Spec.Ingress {
-		var podNSSelector *metav1.LabelSelector
-		if len(rule.From) > 0 && rule.From[0].Pods != nil {
-			podNSSelector = &rule.From[0].Pods.NamespaceSelector
-		}
-		var nsSelector *metav1.LabelSelector
-		if len(rule.From) > 0 {
-			nsSelector = rule.From[0].Namespaces
+		// Mirrors the NetworkPolicy → PolicyEndpoint behavior in
+		// computeIngressEndpoints (pkg/resolvers/endpoints.go), which skips
+		// an ingress rule when its named ports cannot be resolved against
+		// destination pods. Here we short-circuit early when the subject
+		// selector matched no namespaces, so we know there are no
+		// destination pods to resolve named ports against.
+		if subjectNamespace == "" && hasNamedCNPPorts(rule.Ports) {
+			r.logger.Info("Skipping CNP ingress rule with named ports because subject selector matched no namespaces",
+				"policy", cnp.Name, "rule", rule.Name)
+			continue
 		}
 
-		targetNamespaces, err := r.resolveTargetNamespaces(ctx, nsSelector, podNSSelector)
+		tempNP := r.convertSingleCNPIngressRuleToNP(cnp, rule, subjectNamespace)
+		ingressRules, _, _, err := r.baseResolver.Resolve(ctx, tempNP)
 		if err != nil {
 			return nil, err
 		}
-		for _, ns := range targetNamespaces {
-			tempNP := r.convertSingleCNPIngressRuleToNP(cnp, rule, ns)
-			ingressRules, _, _, err := r.baseResolver.Resolve(ctx, tempNP)
-			if err != nil {
-				return nil, err
-			}
 
-			for _, endpoint := range ingressRules {
-				allIngressRules = append(allIngressRules, policyinfo.ClusterEndpointInfo{
-					CIDR:   endpoint.CIDR,
-					Ports:  endpoint.Ports,
-					Action: rule.Action,
-				})
-			}
+		for _, endpoint := range ingressRules {
+			allIngressRules = append(allIngressRules, policyinfo.ClusterEndpointInfo{
+				CIDR:   endpoint.CIDR,
+				Ports:  endpoint.Ports,
+				Action: rule.Action,
+			})
 		}
 	}
 
 	return r.mergeClusterEndpointInfo(allIngressRules), nil
+}
+
+func (r *clusterNetworkPolicyEndpointsResolver) getSubjectNamespace(ctx context.Context, cnp *policyinfo.ClusterNetworkPolicy) (string, error) {
+	if cnp.Spec.Subject.Pods != nil {
+		namespaces, err := r.resolveNamespacesBySelector(ctx, cnp.Spec.Subject.Pods.NamespaceSelector)
+		if err != nil {
+			return "", fmt.Errorf("err in getting subject namespaces using Pods.NamespaceSelector %w", err)
+		}
+		if len(namespaces) > 0 {
+			return namespaces[0], nil
+		}
+	} else if cnp.Spec.Subject.Namespaces != nil {
+		namespaces, err := r.resolveNamespacesBySelector(ctx, *cnp.Spec.Subject.Namespaces)
+		if err != nil {
+			return "", fmt.Errorf("err in getting subject namespaces using Subject.Namespaces %w", err)
+		}
+		if len(namespaces) > 0 {
+			return namespaces[0], nil
+		}
+	}
+	// No namespace matched the subject selector. Returning empty namespace
+	// lets callers decide whether they can safely proceed without a concrete
+	// subject namespace.
+	return "", nil
 }

--- a/pkg/resolvers/clusternetworkpolicy_resolver.go
+++ b/pkg/resolvers/clusternetworkpolicy_resolver.go
@@ -3,6 +3,7 @@ package resolvers
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	policyinfo "github.com/aws/amazon-network-policy-controller-k8s/api/v1alpha1"
@@ -213,8 +214,13 @@ func (r *clusterNetworkPolicyEndpointsResolver) convertCNPPortsToNPPorts(cnpPort
 			})
 		}
 		if cnpPort.NamedPort != nil {
+			// CNP NamedPort has no Protocol field; default to TCP to match
+			// the kubebuilder default on PortNumber/PortRange and prevent
+			// nil-protocol panics in baseResolver.getPortList. This is coming because of CNP to NP API translation.
+			tcp := corev1.ProtocolTCP
 			npPorts = append(npPorts, networking.NetworkPolicyPort{
-				Port: &intstr.IntOrString{Type: intstr.String, StrVal: *cnpPort.NamedPort},
+				Protocol: &tcp,
+				Port:     &intstr.IntOrString{Type: intstr.String, StrVal: *cnpPort.NamedPort},
 			})
 		}
 	}
@@ -263,7 +269,7 @@ func (r *clusterNetworkPolicyEndpointsResolver) resolveCNPEgressRules(ctx contex
 
 	subjectNamespace, err := r.getSubjectNamespace(ctx, cnp)
 	if err != nil {
-		return nil, fmt.Errorf("err in resolving CNP egress rules %w", err)
+		return nil, fmt.Errorf("resolving CNP egress rules: %w", err)
 	}
 
 	for _, rule := range cnp.Spec.Egress {
@@ -353,13 +359,22 @@ func (r *clusterNetworkPolicyEndpointsResolver) convertSingleCNPIngressRuleToNP(
 		ingressRule.Ports = r.convertCNPPortsToNPPorts(*rule.Ports)
 	}
 
+	// Set the temp NP's PodSelector to the CNP's subject pod selector so that
+	// named-port resolution (baseResolver.getIngressRulesPorts) only inspects
+	// destination (subject) pods.
+	var subjectPodSelector metav1.LabelSelector
+	if cnp.Spec.Subject.Pods != nil {
+		subjectPodSelector = cnp.Spec.Subject.Pods.PodSelector
+	}
+
 	return &networking.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cnp.Name,
 			Namespace: namespace,
 		},
 		Spec: networking.NetworkPolicySpec{
-			Ingress: []networking.NetworkPolicyIngressRule{ingressRule},
+			PodSelector: subjectPodSelector,
+			Ingress:     []networking.NetworkPolicyIngressRule{ingressRule},
 		},
 	}
 }
@@ -373,9 +388,13 @@ func (r *clusterNetworkPolicyEndpointsResolver) convertSingleCNPIngressRuleToNP(
 // peer set without an outer namespace loop. DomainNames are skipped here and
 // emitted directly by the caller.
 //
-// The `namespace` argument is unused by baseResolver for egress in practice:
-// egress named ports resolve against destination (peer) pods per-peer, and
-// CIDR peers are namespace-agnostic.
+// The `namespace` argument is set on the temp NP only to keep the
+// NetworkPolicy object well-formed; baseResolver does not consult it for
+// egress so long as every converted peer carries an explicit
+// NamespaceSelector (which is true for CNP-converted peers). Egress named
+// ports resolve against destination (peer) pods per-peer, and CIDR peers are
+// namespace-agnostic. Callers pass the CNP's subject namespace for
+// consistency with the ingress path.
 func (r *clusterNetworkPolicyEndpointsResolver) convertSingleCNPEgressRuleToNP(cnp *policyinfo.ClusterNetworkPolicy, rule policyinfo.ClusterNetworkPolicyEgressRule, namespace string) *networking.NetworkPolicy {
 	// Convert only CIDR/namespace/pod peers, skip domainNames
 	var npPeers []networking.NetworkPolicyPeer
@@ -421,12 +440,13 @@ func (r *clusterNetworkPolicyEndpointsResolver) convertSingleCNPEgressRuleToNP(c
 		},
 	}
 }
+
 func (r *clusterNetworkPolicyEndpointsResolver) resolveCNPIngressRules(ctx context.Context, cnp *policyinfo.ClusterNetworkPolicy) ([]policyinfo.ClusterEndpointInfo, error) {
 	// Determine subject namespace for named port resolution.
 	// Named ports resolve against the policy's destination pods (subject pods).
 	subjectNamespace, err := r.getSubjectNamespace(ctx, cnp)
 	if err != nil {
-		return nil, fmt.Errorf("err in resolving CNP ingress rules %w", err)
+		return nil, fmt.Errorf("resolving CNP ingress rules: %w", err)
 	}
 
 	var allIngressRules []policyinfo.ClusterEndpointInfo
@@ -461,21 +481,33 @@ func (r *clusterNetworkPolicyEndpointsResolver) resolveCNPIngressRules(ctx conte
 	return r.mergeClusterEndpointInfo(allIngressRules), nil
 }
 
+// getSubjectNamespace returns a single namespace from those matching the
+// CNP subject selector, used by callers for named-port resolution against
+// destination pods. The namespace list is sorted before picking [0] so the
+// choice is deterministic across reconciles — k8sClient.List() ordering is
+// not guaranteed stable, and an unstable choice would flip resolved named
+// ports between reconciles when the subject spans multiple namespaces.
+//
+// Note: this is a best-effort approximation. When the subject spans multiple
+// namespaces with named ports declared on different containerPort values,
+// only the chosen namespace's pods contribute to resolution. This is a limitation of the current CPE schema
 func (r *clusterNetworkPolicyEndpointsResolver) getSubjectNamespace(ctx context.Context, cnp *policyinfo.ClusterNetworkPolicy) (string, error) {
 	if cnp.Spec.Subject.Pods != nil {
 		namespaces, err := r.resolveNamespacesBySelector(ctx, cnp.Spec.Subject.Pods.NamespaceSelector)
 		if err != nil {
-			return "", fmt.Errorf("err in getting subject namespaces using Pods.NamespaceSelector %w", err)
+			return "", fmt.Errorf("resolving subject namespaces from Pods.NamespaceSelector: %w", err)
 		}
 		if len(namespaces) > 0 {
+			sort.Strings(namespaces)
 			return namespaces[0], nil
 		}
 	} else if cnp.Spec.Subject.Namespaces != nil {
 		namespaces, err := r.resolveNamespacesBySelector(ctx, *cnp.Spec.Subject.Namespaces)
 		if err != nil {
-			return "", fmt.Errorf("err in getting subject namespaces using Subject.Namespaces %w", err)
+			return "", fmt.Errorf("resolving subject namespaces from Subject.Namespaces: %w", err)
 		}
 		if len(namespaces) > 0 {
+			sort.Strings(namespaces)
 			return namespaces[0], nil
 		}
 	}

--- a/pkg/resolvers/clusternetworkpolicy_resolver_test.go
+++ b/pkg/resolvers/clusternetworkpolicy_resolver_test.go
@@ -1244,7 +1244,7 @@ func TestGetSubjectNamespace(t *testing.T) {
 	tests := []struct {
 		name        string
 		subject     policyinfo.ClusterNetworkPolicySubject
-		wantOneOf   []string // List order non-deterministic; any match is OK.
+		want        string // expected exact namespace (sort.Strings makes this deterministic)
 		wantEmpty   bool
 		expectError bool
 	}{
@@ -1256,21 +1256,45 @@ func TestGetSubjectNamespace(t *testing.T) {
 					PodSelector:       metav1.LabelSelector{},
 				},
 			},
-			wantOneOf: []string{"prod-ns"},
+			want: "prod-ns",
 		},
 		{
 			name: "Namespaces subject with matching label",
 			subject: policyinfo.ClusterNetworkPolicySubject{
 				Namespaces: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "dev"}},
 			},
-			wantOneOf: []string{"dev-ns"},
+			want: "dev-ns",
 		},
 		{
-			name: "Namespaces subject with empty selector returns some namespace",
+			name: "Namespaces subject with empty selector returns alphabetically first",
 			subject: policyinfo.ClusterNetworkPolicySubject{
 				Namespaces: &metav1.LabelSelector{},
 			},
-			wantOneOf: []string{"prod-ns", "dev-ns"},
+			want: "dev-ns", // sort.Strings(["prod-ns","dev-ns"])[0] == "dev-ns"
+		},
+		{
+			name: "Namespaces subject matching multiple namespaces returns alphabetically first",
+			subject: policyinfo.ClusterNetworkPolicySubject{
+				Namespaces: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{Key: "env", Operator: metav1.LabelSelectorOpIn, Values: []string{"prod", "dev"}},
+					},
+				},
+			},
+			want: "dev-ns",
+		},
+		{
+			name: "Pods subject matching multiple namespaces returns alphabetically first",
+			subject: policyinfo.ClusterNetworkPolicySubject{
+				Pods: &policyinfo.NamespacedPod{
+					NamespaceSelector: metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{Key: "env", Operator: metav1.LabelSelectorOpIn, Values: []string{"prod", "dev"}},
+						},
+					},
+				},
+			},
+			want: "dev-ns",
 		},
 		{
 			name: "Pods subject with no matching namespace returns empty",
@@ -1307,7 +1331,7 @@ func TestGetSubjectNamespace(t *testing.T) {
 			if tc.wantEmpty {
 				assert.Empty(t, got)
 			} else {
-				assert.Contains(t, tc.wantOneOf, got)
+				assert.Equal(t, tc.want, got)
 			}
 		})
 	}
@@ -1455,4 +1479,107 @@ func TestResolveCNPIngressRules_NamedPortsWithoutSubjectNamespaceSkipsRule(t *te
 
 	assert.NoError(t, err)
 	assert.Empty(t, result)
+}
+
+// Asserts named-port resolution honors Subject.Pods.PodSelector — non-subject
+// pods in the subject namespace must not contribute their containerPort even
+// if they declare the same named port.
+func TestResolveCNPIngressRules_NamedPortRespectsSubjectPodSelector(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = networking.AddToScheme(scheme)
+	_ = policyinfo.AddToScheme(scheme)
+
+	subjectNS := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "team-alpha", Labels: map[string]string{"team": "alpha"}},
+	}
+	peerNS := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "client-ns", Labels: map[string]string{"role": "client"}},
+	}
+	// Subject pod: matches Subject.Pods.PodSelector {app=web}, declares http=8080.
+	webPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "web-1",
+			Namespace: "team-alpha",
+			Labels:    map[string]string{"app": "web"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "web",
+					Ports: []corev1.ContainerPort{{Name: "http", ContainerPort: 8080, Protocol: corev1.ProtocolTCP}},
+				},
+			},
+		},
+		Status: corev1.PodStatus{PodIP: "10.0.1.1"},
+	}
+	// Non-subject pod: same namespace, app=db, declares http=9999.
+	dbPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "db-1",
+			Namespace: "team-alpha",
+			Labels:    map[string]string{"app": "db"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "db",
+					Ports: []corev1.ContainerPort{{Name: "http", ContainerPort: 9999, Protocol: corev1.ProtocolTCP}},
+				},
+			},
+		},
+		Status: corev1.PodStatus{PodIP: "10.0.1.2"},
+	}
+	clientPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "client-1",
+			Namespace: "client-ns",
+			Labels:    map[string]string{"app": "client"},
+		},
+		Status: corev1.PodStatus{PodIP: "10.0.2.1"},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(subjectNS, peerNS, webPod, dbPod, clientPod).
+		Build()
+	baseResolver := NewEndpointsResolver(fakeClient, logr.Discard())
+	resolver := &clusterNetworkPolicyEndpointsResolver{
+		k8sClient:    fakeClient,
+		baseResolver: baseResolver,
+		logger:       logr.Discard(),
+	}
+
+	namedPort := "http"
+	cnp := &policyinfo.ClusterNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-ingress-named-port"},
+		Spec: policyinfo.ClusterNetworkPolicySpec{
+			Subject: policyinfo.ClusterNetworkPolicySubject{
+				Pods: &policyinfo.NamespacedPod{
+					NamespaceSelector: metav1.LabelSelector{MatchLabels: map[string]string{"team": "alpha"}},
+					PodSelector:       metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+				},
+			},
+			Ingress: []policyinfo.ClusterNetworkPolicyIngressRule{
+				{
+					Name:   "allow-http",
+					Action: policyinfo.ClusterNetworkPolicyRuleActionAccept,
+					From: []policyinfo.ClusterNetworkPolicyIngressPeer{
+						{Namespaces: &metav1.LabelSelector{MatchLabels: map[string]string{"role": "client"}}},
+					},
+					Ports: &[]policyinfo.ClusterNetworkPolicyPort{{NamedPort: &namedPort}},
+				},
+			},
+		},
+	}
+
+	result, err := resolver.resolveCNPIngressRules(context.Background(), cnp)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+
+	// Resolved ports must include only 8080 (web pod), NOT 9999 (db pod).
+	assert.Len(t, result[0].Ports, 1, "named-port resolution should not leak non-subject pod's port")
+	if len(result[0].Ports) > 0 && result[0].Ports[0].Port != nil {
+		assert.Equal(t, int32(8080), *result[0].Ports[0].Port)
+	}
 }

--- a/pkg/resolvers/clusternetworkpolicy_resolver_test.go
+++ b/pkg/resolvers/clusternetworkpolicy_resolver_test.go
@@ -1102,3 +1102,357 @@ func TestClusterNetworkPolicyEndpointsResolver_resolveCNPIngressRules(t *testing
 	assert.Equal(t, "10.1.1.1", string(result[0].CIDR))
 	assert.Equal(t, policyinfo.ClusterNetworkPolicyRuleActionAccept, result[0].Action)
 }
+
+// Asserts Resolve() is called once per ingress rule, not per matched namespace.
+func TestResolveCNPIngressRules_SingleResolveCallPerRule(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = networking.AddToScheme(scheme)
+	_ = policyinfo.AddToScheme(scheme)
+
+	// 5 namespaces match the peer selector.
+	namespaces := make([]runtime.Object, 0, 5)
+	for i := 0; i < 5; i++ {
+		namespaces = append(namespaces, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   fmt.Sprintf("prod-ns-%d", i),
+				Labels: map[string]string{"env": "prod"},
+			},
+		})
+	}
+	subjectNS := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "subject-ns", Labels: map[string]string{"role": "subject"}},
+	}
+	namespaces = append(namespaces, subjectNS)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(namespaces...).
+		Build()
+
+	mockResolver := new(MockEndpointsResolver)
+	resolver := &clusterNetworkPolicyEndpointsResolver{
+		k8sClient:    fakeClient,
+		baseResolver: mockResolver,
+		logger:       logr.Discard(),
+	}
+
+	mockResolver.On("Resolve", mock.Anything, mock.Anything).Return(
+		[]policyinfo.EndpointInfo{{CIDR: "10.0.0.1"}},
+		[]policyinfo.EndpointInfo(nil),
+		[]policyinfo.PodEndpoint(nil),
+		nil,
+	)
+
+	cnp := &policyinfo.ClusterNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		Spec: policyinfo.ClusterNetworkPolicySpec{
+			Subject: policyinfo.ClusterNetworkPolicySubject{
+				Namespaces: &metav1.LabelSelector{MatchLabels: map[string]string{"role": "subject"}},
+			},
+			Ingress: []policyinfo.ClusterNetworkPolicyIngressRule{
+				{
+					Name:   "rule-a",
+					Action: policyinfo.ClusterNetworkPolicyRuleActionAccept,
+					From:   []policyinfo.ClusterNetworkPolicyIngressPeer{{Namespaces: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}}}},
+				},
+				{
+					Name:   "rule-b",
+					Action: policyinfo.ClusterNetworkPolicyRuleActionAccept,
+					From:   []policyinfo.ClusterNetworkPolicyIngressPeer{{Namespaces: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}}}},
+				},
+			},
+		},
+	}
+
+	_, err := resolver.resolveCNPIngressRules(context.Background(), cnp)
+	assert.NoError(t, err)
+	// 2 rules × 5 matched namespaces → expect 2 calls (one per rule), not 10.
+	mockResolver.AssertNumberOfCalls(t, "Resolve", 2)
+}
+
+// Asserts Resolve() is called once per egress NS/Pod peer, not per matched namespace.
+func TestResolveCNPEgressRules_SingleResolveCallForNamespacePeer(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = networking.AddToScheme(scheme)
+	_ = policyinfo.AddToScheme(scheme)
+
+	namespaces := make([]runtime.Object, 0, 5)
+	for i := 0; i < 5; i++ {
+		namespaces = append(namespaces, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   fmt.Sprintf("prod-ns-%d", i),
+				Labels: map[string]string{"env": "prod"},
+			},
+		})
+	}
+	subjectNS := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "subject-ns", Labels: map[string]string{"role": "subject"}},
+	}
+	namespaces = append(namespaces, subjectNS)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(namespaces...).
+		Build()
+
+	mockResolver := new(MockEndpointsResolver)
+	resolver := &clusterNetworkPolicyEndpointsResolver{
+		k8sClient:    fakeClient,
+		baseResolver: mockResolver,
+		logger:       logr.Discard(),
+	}
+
+	mockResolver.On("Resolve", mock.Anything, mock.Anything).Return(
+		[]policyinfo.EndpointInfo(nil),
+		[]policyinfo.EndpointInfo{{CIDR: "10.0.0.1"}},
+		[]policyinfo.PodEndpoint(nil),
+		nil,
+	)
+
+	cnp := &policyinfo.ClusterNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		Spec: policyinfo.ClusterNetworkPolicySpec{
+			Subject: policyinfo.ClusterNetworkPolicySubject{
+				Namespaces: &metav1.LabelSelector{MatchLabels: map[string]string{"role": "subject"}},
+			},
+			Egress: []policyinfo.ClusterNetworkPolicyEgressRule{
+				{
+					Name:   "rule-1",
+					Action: policyinfo.ClusterNetworkPolicyRuleActionAccept,
+					To:     []policyinfo.ClusterNetworkPolicyEgressPeer{{Namespaces: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}}}},
+				},
+			},
+		},
+	}
+
+	_, err := resolver.resolveCNPEgressRules(context.Background(), cnp)
+	assert.NoError(t, err)
+	// NS peer matches 5 namespaces → expect 1 call, not 5.
+	mockResolver.AssertNumberOfCalls(t, "Resolve", 1)
+}
+
+// Covers getSubjectNamespace for Pods/Namespaces subject + no-match cases.
+func TestGetSubjectNamespace(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	prodNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "prod-ns", Labels: map[string]string{"env": "prod"}}}
+	devNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "dev-ns", Labels: map[string]string{"env": "dev"}}}
+
+	tests := []struct {
+		name        string
+		subject     policyinfo.ClusterNetworkPolicySubject
+		wantOneOf   []string // List order non-deterministic; any match is OK.
+		wantEmpty   bool
+		expectError bool
+	}{
+		{
+			name: "Pods subject with matching namespace",
+			subject: policyinfo.ClusterNetworkPolicySubject{
+				Pods: &policyinfo.NamespacedPod{
+					NamespaceSelector: metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}},
+					PodSelector:       metav1.LabelSelector{},
+				},
+			},
+			wantOneOf: []string{"prod-ns"},
+		},
+		{
+			name: "Namespaces subject with matching label",
+			subject: policyinfo.ClusterNetworkPolicySubject{
+				Namespaces: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "dev"}},
+			},
+			wantOneOf: []string{"dev-ns"},
+		},
+		{
+			name: "Namespaces subject with empty selector returns some namespace",
+			subject: policyinfo.ClusterNetworkPolicySubject{
+				Namespaces: &metav1.LabelSelector{},
+			},
+			wantOneOf: []string{"prod-ns", "dev-ns"},
+		},
+		{
+			name: "Pods subject with no matching namespace returns empty",
+			subject: policyinfo.ClusterNetworkPolicySubject{
+				Pods: &policyinfo.NamespacedPod{
+					NamespaceSelector: metav1.LabelSelector{MatchLabels: map[string]string{"env": "nope"}},
+				},
+			},
+			wantEmpty: true,
+		},
+		{
+			name:      "empty subject returns empty",
+			subject:   policyinfo.ClusterNetworkPolicySubject{},
+			wantEmpty: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(prodNS, devNS).
+				Build()
+			resolver := &clusterNetworkPolicyEndpointsResolver{
+				k8sClient: fakeClient,
+				logger:    logr.Discard(),
+			}
+			cnp := &policyinfo.ClusterNetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec:       policyinfo.ClusterNetworkPolicySpec{Subject: tc.subject},
+			}
+			got, err := resolver.getSubjectNamespace(context.Background(), cnp)
+			assert.NoError(t, err)
+			if tc.wantEmpty {
+				assert.Empty(t, got)
+			} else {
+				assert.Contains(t, tc.wantOneOf, got)
+			}
+		})
+	}
+}
+
+// Asserts temp NP namespace = subject namespace (for named-port resolution).
+func TestResolveCNPIngressRules_TempNPNamespaceIsSubject(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = networking.AddToScheme(scheme)
+	_ = policyinfo.AddToScheme(scheme)
+
+	subjectNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "sub-ns", Labels: map[string]string{"role": "subject"}}}
+	peerNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "peer-ns", Labels: map[string]string{"env": "prod"}}}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(subjectNS, peerNS).
+		Build()
+
+	mockResolver := new(MockEndpointsResolver)
+	resolver := &clusterNetworkPolicyEndpointsResolver{
+		k8sClient:    fakeClient,
+		baseResolver: mockResolver,
+		logger:       logr.Discard(),
+	}
+
+	var capturedNS string
+	mockResolver.On("Resolve", mock.Anything, mock.MatchedBy(func(np *networking.NetworkPolicy) bool {
+		capturedNS = np.Namespace
+		return true
+	})).Return(
+		[]policyinfo.EndpointInfo(nil),
+		[]policyinfo.EndpointInfo(nil),
+		[]policyinfo.PodEndpoint(nil),
+		nil,
+	)
+
+	cnp := &policyinfo.ClusterNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		Spec: policyinfo.ClusterNetworkPolicySpec{
+			Subject: policyinfo.ClusterNetworkPolicySubject{
+				Namespaces: &metav1.LabelSelector{MatchLabels: map[string]string{"role": "subject"}},
+			},
+			Ingress: []policyinfo.ClusterNetworkPolicyIngressRule{
+				{
+					Name:   "rule-1",
+					Action: policyinfo.ClusterNetworkPolicyRuleActionAccept,
+					From:   []policyinfo.ClusterNetworkPolicyIngressPeer{{Namespaces: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}}}},
+				},
+			},
+		},
+	}
+
+	_, err := resolver.resolveCNPIngressRules(context.Background(), cnp)
+	assert.NoError(t, err)
+	assert.Equal(t, "sub-ns", capturedNS) // subject ns, not peer ns
+}
+
+func TestResolveCNPIngressRules_NamedPortsWithoutSubjectNamespaceSkipsRule(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = networking.AddToScheme(scheme)
+	_ = policyinfo.AddToScheme(scheme)
+
+	peerNS := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "peer-ns",
+			Labels: map[string]string{"env": "prod"},
+		},
+	}
+	otherNS := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "other-ns",
+			Labels: map[string]string{"env": "other"},
+		},
+	}
+	peerPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "peer-pod",
+			Namespace: "peer-ns",
+		},
+		Status: corev1.PodStatus{
+			PodIP: "10.1.1.1",
+		},
+	}
+	unrelatedPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unrelated-pod",
+			Namespace: "other-ns",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "app",
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          "http",
+							ContainerPort: 8080,
+							Protocol:      corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			PodIP: "10.2.2.2",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(peerNS, otherNS, peerPod, unrelatedPod).
+		Build()
+	baseResolver := NewEndpointsResolver(fakeClient, logr.Discard())
+	resolver := &clusterNetworkPolicyEndpointsResolver{
+		k8sClient:    fakeClient,
+		baseResolver: baseResolver,
+		logger:       logr.Discard(),
+	}
+
+	namedPort := "http"
+	cnp := &policyinfo.ClusterNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cnp"},
+		Spec: policyinfo.ClusterNetworkPolicySpec{
+			Subject: policyinfo.ClusterNetworkPolicySubject{
+				Namespaces: &metav1.LabelSelector{MatchLabels: map[string]string{"role": "subject"}},
+			},
+			Ingress: []policyinfo.ClusterNetworkPolicyIngressRule{
+				{
+					Name:   "ingress-rule",
+					Action: policyinfo.ClusterNetworkPolicyRuleActionAccept,
+					From: []policyinfo.ClusterNetworkPolicyIngressPeer{
+						{Namespaces: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}}},
+					},
+					Ports: &[]policyinfo.ClusterNetworkPolicyPort{
+						{NamedPort: &namedPort},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := resolver.resolveCNPIngressRules(context.Background(), cnp)
+
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
perf improvement and kinda bug fix

**Which issue does this PR fix**:
This PR fixes perf issues in CNP reconciliation logic which does redundant work and results in high reconcile latencies

### Before (9.8)
```
{"level":"info","ts":"2026-05-15T15:31:42Z","logger":"endpoints-manager","msg":"CNP reconcile phase durations","policy":"admin-otel-ingress-telemetry","computeDuration":9.355258908,"crudDuration":0.483804253,"create":0,"update":23,"delete":0}
{"level":"info","ts":"2026-05-15T15:31:42Z","logger":"controllers.policy","msg":"Reconcile completed","resource":{"name":"admin-otel-ingress-telemetry"},"duration":9.839130202,"success":true}
```


### After (0.2)
```
{"level":"info","ts":"2026-05-15T15:36:15Z","logger":"endpoints-manager","msg":"CNP reconcile phase durations","policy":"admin-otel-ingress-telemetry","computeDuration":0.139559432,"crudDuration":0.139655225,"create":0,"update":23,"delete":0}
{"level":"info","ts":"2026-05-15T15:36:15Z","logger":"controllers.policy","msg":"Reconcile completed","resource":{"name":"admin-otel-ingress-telemetry"},"duration":0.279341531,"success":true}
```

**What does this PR do / Why do we need it**:

> Context

CNP-converted peers always have explicit NamespaceSelector, so baseResolver.resolvePeerNamespaces resolves namespaces from the selector and ignores the temp NP's namespace. The outer `for _, ns := range targetNamespaces` loop in resolveCNPIngressRules and resolveCNPEgressRules was therefore calling Resolve() N times with identical inputs.

Replace per-namespace loop with single Resolve() call per rule/peer, using subjectNamespace (first matching subject namespace) only for named port resolution against destination pods.

**If an issue # is not available please add steps to reproduce and the controller logs**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
- UT
- IT (WIP)

**Automation added to e2e**:
<!--
List the e2e tests you added as part of this PR.
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new K8s API
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.