### PR TITLE
fix: nil pointer dereference in convertToPolicyInfoPortForCIDRs and bump up docker version in gh workflow

### DIFF
--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -55,9 +55,9 @@ jobs:
           check-latest: true
           cache-dependency-path: "**/go.sum"
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Build Network Policy Controller images
         run: make docker-buildx
   deprecated-apigroups:

--- a/pkg/resolvers/endpoints.go
+++ b/pkg/resolvers/endpoints.go
@@ -378,7 +378,10 @@ func (r *defaultEndpointsResolver) getPortList(pod corev1.Pod, ports []networkin
 // convertToPolicyInfoPortForCIDRs converts the NetworkPolicyPort to policyinfo.Port. This is used for CIDR based
 // rules where it is not possible to resolve the named ports.
 func (r *defaultEndpointsResolver) convertToPolicyInfoPortForCIDRs(port networking.NetworkPolicyPort) *policyinfo.Port {
-	protocol := *port.Protocol
+	protocol := corev1.ProtocolTCP
+	if port.Protocol != nil {
+		protocol = *port.Protocol
+	}
 	switch {
 	case port.Port == nil:
 		return &policyinfo.Port{

--- a/pkg/resolvers/endpoints_test.go
+++ b/pkg/resolvers/endpoints_test.go
@@ -496,6 +496,45 @@ func TestEndpointsResolver_Resolve(t *testing.T) {
 			},
 		},
 		{
+			name: "egress ipBlock CIDR with nil Protocol defaults to TCP",
+			args: args{
+				netpol: &networking.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "nil-proto",
+						Namespace: "ns",
+					},
+					Spec: networking.NetworkPolicySpec{
+						PodSelector: metav1.LabelSelector{},
+						PolicyTypes: []networking.PolicyType{networking.PolicyTypeEgress},
+						Egress: []networking.NetworkPolicyEgressRule{
+							{
+								To: []networking.NetworkPolicyPeer{
+									{
+										IPBlock: &networking.IPBlock{
+											CIDR: "10.20.10.0/24",
+										},
+									},
+								},
+								Ports: []networking.NetworkPolicyPort{
+									{
+										Port: &intOrStrPort80,
+									},
+								},
+							},
+						},
+					},
+				},
+				podListCalls: []podListCall{
+					{
+						pods: []corev1.Pod{},
+					},
+				},
+			},
+			wantEgressEndpoints: []policyinfo.EndpointInfo{
+				{CIDR: "10.20.10.0/24", Ports: []policyinfo.Port{{Protocol: &protocolTCP, Port: &port80}}},
+			},
+		},
+		{
 			name: "allow all, ingress/egress to specific ports",
 			args: args{
 				netpol: &networking.NetworkPolicy{

--- a/pkg/resolvers/endpoints_test.go
+++ b/pkg/resolvers/endpoints_test.go
@@ -535,6 +535,40 @@ func TestEndpointsResolver_Resolve(t *testing.T) {
 			},
 		},
 		{
+			name: "egress ipBlock CIDR with nil Ports allows all traffic",
+			args: args{
+				netpol: &networking.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "nil-ports",
+						Namespace: "ns",
+					},
+					Spec: networking.NetworkPolicySpec{
+						PodSelector: metav1.LabelSelector{},
+						PolicyTypes: []networking.PolicyType{networking.PolicyTypeEgress},
+						Egress: []networking.NetworkPolicyEgressRule{
+							{
+								To: []networking.NetworkPolicyPeer{
+									{
+										IPBlock: &networking.IPBlock{
+											CIDR: "10.20.10.0/24",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				podListCalls: []podListCall{
+					{
+						pods: []corev1.Pod{},
+					},
+				},
+			},
+			wantEgressEndpoints: []policyinfo.EndpointInfo{
+				{CIDR: "10.20.10.0/24"},
+			},
+		},
+		{
 			name: "allow all, ingress/egress to specific ports",
 			args: args{
 				netpol: &networking.NetworkPolicy{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
bug
**Which issue does this PR fix**:
1. convertToPolicyInfoPortForCIDRs at endpoints.go:381 unconditionally dereferences port.Protocol (protocol := *port.Protocol). The K8s NetworkPolicy API allows Protocol to be nil (defaults to TCP per spec), but NPC panics when it encounters this. This causes a SIGSEGV crash-loop whenever an ANP/NP has an egress ipBlock CIDR rule with a port that omits the protocol field.

The fix adds a nil guard and defaults to corev1.ProtocolTCP, matching the existing pattern already used at line 521 of the same file.

2. bump up docker version to v3 for gh action failure fix.
**What does this PR do / Why do we need it**:


**If an issue # is not available please add steps to reproduce and the controller logs**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Unit test added: TestEndpointsResolver_Resolve/egress_ipBlock_CIDR_with_nil_Protocol_defaults_to_TCP

  Verified the test reproduces the exact same panic against the unfixed code:
  panic: runtime error: invalid memory address or nil pointer dereference
  [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x1434641]
  resolvers.(*defaultEndpointsResolver).convertToPolicyInfoPortForCIDRs  endpoints.go:381

  And passes with the fix applied:
  --- PASS: TestEndpointsResolver_Resolve/egress_ipBlock_CIDR_with_nil_Protocol_defaults_to_TCP (0.00s)
  PASS

  Full unit test suite passes: ok github.com/aws/amazon-network-policy-controller-k8s/pkg/resolvers 0.029s
**Automation added to e2e**:
<!--
List the e2e tests you added as part of this PR.
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new K8s API
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.