### PR TITLE
fix #238: update podSelector in existing PolicyEndpoints when changed

### DIFF
--- a/pkg/policyendpoints/manager.go
+++ b/pkg/policyendpoints/manager.go
@@ -269,7 +269,7 @@ func (m *policyEndpointsManager) computePolicyEndpoints(policy *networking.Netwo
 	// Loop through ingressEndpoints, egressEndpoints and podSelectorEndpoints and put in map
 	// also populate them into policy endpoints
 	ingressEndpointsMap, egressEndpointsMap, podSelectorEndpointSet, modifiedEndpoints, potentialDeletes := m.processExistingPolicyEndpoints(
-		policy.Spec.PolicyTypes, existingPolicyEndpoints, ingressEndpoints, egressEndpoints, podSelectorEndpoints,
+		policy.Spec.PolicyTypes, policy.Spec.PodSelector, existingPolicyEndpoints, ingressEndpoints, egressEndpoints, podSelectorEndpoints,
 	)
 
 	doNotDelete := sets.Set[types.NamespacedName]{}
@@ -466,6 +466,7 @@ func (m *policyEndpointsManager) getEndpointInfoKey(info policyinfo.EndpointInfo
 // it returns required rules and pod selector changes, and potential modifications and deletions on policy endpoints.
 func (m *policyEndpointsManager) processExistingPolicyEndpoints(
 	policyTypes []networking.PolicyType,
+	podSelector metav1.LabelSelector,
 	existingPolicyEndpoints []policyinfo.PolicyEndpoint, ingressEndpoints []policyinfo.EndpointInfo,
 	egressEndpoints []policyinfo.EndpointInfo, podSelectorEndpoints []policyinfo.PodEndpoint,
 ) (
@@ -523,6 +524,10 @@ func (m *policyEndpointsManager) processExistingPolicyEndpoints(
 		policyEndpointChanged := false
 		if !equality.Semantic.DeepEqual(policyTypes, existingPolicyEndpoints[i].Spec.PodIsolation) {
 			existingPolicyEndpoints[i].Spec.PodIsolation = policyTypes
+			policyEndpointChanged = true
+		}
+		if existingPolicyEndpoints[i].Spec.PodSelector == nil || !equality.Semantic.DeepEqual(podSelector, *existingPolicyEndpoints[i].Spec.PodSelector) {
+			existingPolicyEndpoints[i].Spec.PodSelector = &podSelector
 			policyEndpointChanged = true
 		}
 
@@ -682,7 +687,7 @@ func (m *policyEndpointsManager) computeApplicationNetworkPolicyEndpoints(anp *p
 
 	// Process existing endpoints for ANP
 	ingressEndpointsMap, egressEndpointsMap, podSelectorEndpointSet, modifiedEndpoints, potentialDeletes := m.processExistingPolicyEndpoints(
-		anp.Spec.PolicyTypes, existingPolicyEndpoints, ingressEndpoints, egressEndpoints, podSelectorEndpoints,
+		anp.Spec.PolicyTypes, anp.Spec.PodSelector, existingPolicyEndpoints, ingressEndpoints, egressEndpoints, podSelectorEndpoints,
 	)
 
 	doNotDelete := sets.Set[types.NamespacedName]{}

--- a/pkg/policyendpoints/manager_test.go
+++ b/pkg/policyendpoints/manager_test.go
@@ -450,6 +450,51 @@ func Test_policyEndpointsManager_computePolicyEndpoints(t *testing.T) {
 				updateCount: 1,
 			},
 		},
+		{
+			name: "podSelector change updates existing PolicyEndpoint",
+			fields: fields{
+				endpointChunkSize: 100,
+			},
+			args: args{
+				policy: &networking.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "policy-namespace",
+						Name:      "policy-name",
+					},
+					Spec: networking.NetworkPolicySpec{
+						PodSelector: metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "disabled"},
+						},
+						Egress: []networking.NetworkPolicyEgressRule{{}},
+					},
+				},
+				policyEndpoints: []policyinfo.PolicyEndpoint{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "policy-namespace",
+							Name:      "policy-name",
+						},
+						Spec: policyinfo.PolicyEndpointSpec{
+							PodSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"app": "bar"},
+							},
+							Egress: getEPInfoHelper([]policyinfo.NetworkAddress{"1.2.3.4"}, nil, 1),
+							PodSelectorEndpoints: []policyinfo.PodEndpoint{
+								{Name: "pod1", HostIP: "10.0.0.1", PodIP: "192.168.1.1"},
+							},
+						},
+					},
+				},
+				egressRules:          getEPInfoHelper([]policyinfo.NetworkAddress{"1.2.3.4"}, nil, 1),
+				podselectorEndpoints: nil,
+				epValidator: func(netpol *networking.NetworkPolicy, ep *policyinfo.PolicyEndpoint) bool {
+					return equality.Semantic.DeepEqual(ep.Spec.PodSelector, &netpol.Spec.PodSelector)
+				},
+			},
+			want: want{
+				updateCount: 1,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
⏺ What type of PR is this?
  Bug fix

  Which issue does this PR fix:
  Fixes aws/aws-network-policy-agent#643

  What does this PR do / Why do we need it:
  When a `NetworkPolicy's podSelector` is updated, the corresponding `PolicyEndpoint` was not reconciled — it retained the old selector and `podSelectorEndpoints` list, causing the agent to keep enforcing stale
  rules at the dataplane level.

  Root cause: `processExistingPolicyEndpoints` updated `PodIsolation` when policyTypes changed but never updated `Spec.PodSelector` on existing `PolicyEndpoint` objects. The stale modifiedEndpoints were passed to the
  update path where `EqualPolicyEndpointSpec` compared old == new (both had the old selector), skipped the `Patch`, and the `PolicyEndpoint` was never written.

  Fix: add `podSelector metav1.LabelSelector` param to `processExistingPolicyEndpoints` and detect/apply selector changes using the same pattern as `PodIsolation`. Updated both call sites — `computePolicyEndpoints`
  (NP) and `computeApplicationNetworkPolicyEndpoints (ANP)`, which had the same gap.

  If an issue # is not available please add steps to reproduce and the controller logs:
  N/A — see aws/aws-network-policy-agent#643

  Testing done on this change:
  - Added unit test `podSelector_change_updates_existing_PolicyEndpoint`: existing PolicyEndpoint with {app:bar}, policy updated to {app:disabled}, asserts 1 update with Spec.PodSelector reflecting new selector
  and empty PodSelectorEndpoints
  - Full suite: go test ./... — all pass
  - Static analysis: go vet ./... — clean
  
  Automation added to e2e:
  No

  Will this PR introduce any new dependencies?:
  No

  Will this break upgrades or downgrades. Has updating a running cluster been tested?:
  No breaking change. Existing PolicyEndpoints with nil Spec.PodSelector are handled — the nil check ensures they get updated on next reconcile.

  Does this PR introduce any user-facing change?:
  Yes. PolicyEndpoints now correctly reconcile when a NetworkPolicy's podSelector is changed, eliminating stale enforcement without requiring manual deletion of the PolicyEndpoint.

  ---
  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
  