### PR TITLE
Fix: nil protocol dereference in getportlist

### DIFF
--- a/pkg/resolvers/endpoints.go
+++ b/pkg/resolvers/endpoints.go
@@ -355,9 +355,13 @@ func (r *defaultEndpointsResolver) getIngressRulesPorts(ctx context.Context, pol
 func (r *defaultEndpointsResolver) getPortList(pod corev1.Pod, ports []networking.NetworkPolicyPort) []policyinfo.Port {
 	var portList []policyinfo.Port
 	for _, port := range ports {
+		protocol := corev1.ProtocolTCP
+		if port.Protocol != nil {
+			protocol = *port.Protocol
+		}
 		var portPtr *int32
 		if port.Port != nil {
-			portVal, _, err := k8s.LookupContainerPortAndName(&pod, *port.Port, *port.Protocol)
+			portVal, _, err := k8s.LookupContainerPortAndName(&pod, *port.Port, protocol)
 			if err != nil {
 				// Isolate the pod for the port if we are unable to resolve the named port
 				r.logger.Info("Unable to lookup container port", "pod", k8s.NamespacedName(&pod),
@@ -367,7 +371,7 @@ func (r *defaultEndpointsResolver) getPortList(pod corev1.Pod, ports []networkin
 			portPtr = &portVal
 		}
 		portList = append(portList, policyinfo.Port{
-			Protocol: port.Protocol,
+			Protocol: &protocol,
 			Port:     portPtr,
 			EndPort:  port.EndPort,
 		})
@@ -519,12 +523,12 @@ func (r *defaultEndpointsResolver) getMatchingServiceClusterIPs(ctx context.Cont
 
 		var portList []policyinfo.Port
 		for _, npPort := range npPorts {
+			npProto := corev1.ProtocolTCP
+			if npPort.Protocol != nil {
+				npProto = *npPort.Protocol
+			}
 			var portPtr *int32
 			if npPort.Port != nil {
-				npProto := corev1.ProtocolTCP
-				if npPort.Protocol != nil {
-					npProto = *npPort.Protocol
-				}
 				portVal, err := r.getMatchingServicePort(svc, npPort.Port, npProto, getAllPods)
 				if err != nil {
 					r.logger.Info("Unable to lookup service port", "err", err)
@@ -544,7 +548,7 @@ func (r *defaultEndpointsResolver) getMatchingServiceClusterIPs(ctx context.Cont
 				portPtr = &portVal
 			}
 			portList = append(portList, policyinfo.Port{
-				Protocol: npPort.Protocol,
+				Protocol: &npProto,
 				Port:     portPtr,
 				EndPort:  npPort.EndPort,
 			})

--- a/pkg/resolvers/endpoints_test.go
+++ b/pkg/resolvers/endpoints_test.go
@@ -2395,3 +2395,269 @@ func TestGetMatchingServiceClusterIPs_LazyPodFetch(t *testing.T) {
 func int32Ptr(i int32) *int32 {
 	return &i
 }
+
+func TestGetMatchingServiceClusterIPs_NilProtocolDefaultsTCP(t *testing.T) {
+	port80 := intstr.FromInt(80)
+
+	npPorts := []networking.NetworkPolicyPort{
+		{Port: &port80},
+	}
+	ls := &metav1.LabelSelector{}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := mock_client.NewMockClient(ctrl)
+	resolver := NewEndpointsResolver(mockClient, logr.New(&log.NullLogSink{}))
+
+	svc := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc1", Namespace: "ns"},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.0.0.1",
+			Selector:  map[string]string{"app": "web"},
+			Ports: []corev1.ServicePort{
+				{Port: 80, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(80)},
+			},
+		},
+	}
+
+	mockClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.ServiceList{}), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+			list.(*corev1.ServiceList).Items = []corev1.Service{svc}
+			return nil
+		})
+
+	result := resolver.getMatchingServiceClusterIPs(context.Background(), ls, "ns", npPorts)
+	require.Len(t, result, 1)
+	assert.Equal(t, policyinfo.NetworkAddress("10.0.0.1"), result[0].CIDR)
+	require.Len(t, result[0].Ports, 1)
+	require.NotNil(t, result[0].Ports[0].Protocol, "Protocol must not be nil when NP port omits protocol")
+	assert.Equal(t, corev1.ProtocolTCP, *result[0].Ports[0].Protocol)
+}
+
+func TestEndpointsResolver_getPortList(t *testing.T) {
+	protocolTCP := corev1.ProtocolTCP
+	protocolUDP := corev1.ProtocolUDP
+
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Ports: []corev1.ContainerPort{
+						{Name: "http", ContainerPort: 80, Protocol: corev1.ProtocolTCP},
+						{Name: "metrics", ContainerPort: 9090, Protocol: corev1.ProtocolTCP},
+						{Name: "dns", ContainerPort: 53, Protocol: corev1.ProtocolUDP},
+					},
+				},
+			},
+		},
+	}
+
+	namedPortHTTP := intstr.FromString("http")
+	namedPortMetrics := intstr.FromString("metrics")
+	namedPortDNS := intstr.FromString("dns")
+	numericPort80 := intstr.FromInt(80)
+	numericPort443 := intstr.FromInt(443)
+
+	var port80 int32 = 80
+	var port443 int32 = 443
+	var port9090 int32 = 9090
+	var port53 int32 = 53
+
+	tests := []struct {
+		name     string
+		ports    []networking.NetworkPolicyPort
+		wantLen  int
+		wantPort []policyinfo.Port
+	}{
+		{
+			name: "nil Protocol + named port defaults to TCP",
+			ports: []networking.NetworkPolicyPort{
+				{Port: &namedPortHTTP},
+			},
+			wantLen: 1,
+			wantPort: []policyinfo.Port{
+				{Protocol: &protocolTCP, Port: &port80},
+			},
+		},
+		{
+			name: "nil Protocol + numeric port defaults to TCP",
+			ports: []networking.NetworkPolicyPort{
+				{Port: &numericPort80},
+			},
+			wantLen: 1,
+			wantPort: []policyinfo.Port{
+				{Protocol: &protocolTCP, Port: &port80},
+			},
+		},
+		{
+			name: "nil Protocol + nil Port (protocol-only entry) defaults to TCP",
+			ports: []networking.NetworkPolicyPort{
+				{},
+			},
+			wantLen: 1,
+			wantPort: []policyinfo.Port{
+				{Protocol: &protocolTCP},
+			},
+		},
+		{
+			name: "explicit TCP Protocol + named port",
+			ports: []networking.NetworkPolicyPort{
+				{Protocol: &protocolTCP, Port: &namedPortMetrics},
+			},
+			wantLen: 1,
+			wantPort: []policyinfo.Port{
+				{Protocol: &protocolTCP, Port: &port9090},
+			},
+		},
+		{
+			name: "explicit UDP Protocol + named port",
+			ports: []networking.NetworkPolicyPort{
+				{Protocol: &protocolUDP, Port: &namedPortDNS},
+			},
+			wantLen: 1,
+			wantPort: []policyinfo.Port{
+				{Protocol: &protocolUDP, Port: &port53},
+			},
+		},
+		{
+			name: "explicit TCP Protocol + numeric port",
+			ports: []networking.NetworkPolicyPort{
+				{Protocol: &protocolTCP, Port: &numericPort443},
+			},
+			wantLen: 1,
+			wantPort: []policyinfo.Port{
+				{Protocol: &protocolTCP, Port: &port443},
+			},
+		},
+		{
+			name: "mixed: named+TCP followed by numeric nil-protocol (RCA Repro 3)",
+			ports: []networking.NetworkPolicyPort{
+				{Protocol: &protocolTCP, Port: &namedPortHTTP},
+				{Port: &numericPort443},
+			},
+			wantLen: 2,
+			wantPort: []policyinfo.Port{
+				{Protocol: &protocolTCP, Port: &port80},
+				{Protocol: &protocolTCP, Port: &port443},
+			},
+		},
+		{
+			name: "multiple nil-Protocol entries: named and numeric",
+			ports: []networking.NetworkPolicyPort{
+				{Port: &namedPortHTTP},
+				{Port: &numericPort443},
+				{Port: &namedPortMetrics},
+			},
+			wantLen: 3,
+			wantPort: []policyinfo.Port{
+				{Protocol: &protocolTCP, Port: &port80},
+				{Protocol: &protocolTCP, Port: &port443},
+				{Protocol: &protocolTCP, Port: &port9090},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver := &defaultEndpointsResolver{
+				logger: logr.Discard(),
+			}
+			result := resolver.getPortList(pod, tt.ports)
+			require.Len(t, result, tt.wantLen)
+			for i, want := range tt.wantPort {
+				require.NotNil(t, result[i].Protocol, "Protocol must not be nil at index %d", i)
+				assert.Equal(t, *want.Protocol, *result[i].Protocol, "Protocol mismatch at index %d", i)
+				if want.Port != nil {
+					require.NotNil(t, result[i].Port, "Port must not be nil at index %d", i)
+					assert.Equal(t, *want.Port, *result[i].Port, "Port value mismatch at index %d", i)
+				} else {
+					assert.Nil(t, result[i].Port, "Port should be nil at index %d", i)
+				}
+			}
+		})
+	}
+}
+
+func TestEndpointsResolver_convertToPolicyInfoPortForCIDRs(t *testing.T) {
+	protocolTCP := corev1.ProtocolTCP
+	protocolUDP := corev1.ProtocolUDP
+
+	numericPort80 := intstr.FromInt(80)
+	numericPort443 := intstr.FromInt(443)
+	namedPortHTTP := intstr.FromString("http")
+	var port80 int32 = 80
+	var port443 int32 = 443
+	var endPort8080 int32 = 8080
+
+	tests := []struct {
+		name string
+		port networking.NetworkPolicyPort
+		want *policyinfo.Port
+	}{
+		{
+			name: "nil Protocol + numeric port defaults to TCP",
+			port: networking.NetworkPolicyPort{Port: &numericPort80},
+			want: &policyinfo.Port{Protocol: &protocolTCP, Port: &port80},
+		},
+		{
+			name: "nil Protocol + nil Port (protocol-only) defaults to TCP",
+			port: networking.NetworkPolicyPort{},
+			want: &policyinfo.Port{Protocol: &protocolTCP},
+		},
+		{
+			name: "nil Protocol + named port returns nil (cannot resolve without pod)",
+			port: networking.NetworkPolicyPort{Port: &namedPortHTTP},
+			want: nil,
+		},
+		{
+			name: "explicit TCP Protocol + numeric port",
+			port: networking.NetworkPolicyPort{Protocol: &protocolTCP, Port: &numericPort443},
+			want: &policyinfo.Port{Protocol: &protocolTCP, Port: &port443},
+		},
+		{
+			name: "explicit UDP Protocol + numeric port",
+			port: networking.NetworkPolicyPort{Protocol: &protocolUDP, Port: &numericPort80},
+			want: &policyinfo.Port{Protocol: &protocolUDP, Port: &port80},
+		},
+		{
+			name: "EndPort passthrough",
+			port: networking.NetworkPolicyPort{Protocol: &protocolTCP, Port: &numericPort80, EndPort: &endPort8080},
+			want: &policyinfo.Port{Protocol: &protocolTCP, Port: &port80, EndPort: &endPort8080},
+		},
+		{
+			name: "nil Protocol + numeric port + EndPort",
+			port: networking.NetworkPolicyPort{Port: &numericPort80, EndPort: &endPort8080},
+			want: &policyinfo.Port{Protocol: &protocolTCP, Port: &port80, EndPort: &endPort8080},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver := &defaultEndpointsResolver{
+				logger: logr.Discard(),
+			}
+			result := resolver.convertToPolicyInfoPortForCIDRs(tt.port)
+			if tt.want == nil {
+				assert.Nil(t, result)
+				return
+			}
+			require.NotNil(t, result)
+			require.NotNil(t, result.Protocol, "Protocol must not be nil")
+			assert.Equal(t, *tt.want.Protocol, *result.Protocol)
+			if tt.want.Port != nil {
+				require.NotNil(t, result.Port)
+				assert.Equal(t, *tt.want.Port, *result.Port)
+			} else {
+				assert.Nil(t, result.Port)
+			}
+			if tt.want.EndPort != nil {
+				require.NotNil(t, result.EndPort)
+				assert.Equal(t, *tt.want.EndPort, *result.EndPort)
+			} else {
+				assert.Nil(t, result.EndPort)
+			}
+		})
+	}
+}

--- a/pkg/resolvers/endpoints_test.go
+++ b/pkg/resolvers/endpoints_test.go
@@ -2433,6 +2433,42 @@ func TestGetMatchingServiceClusterIPs_NilProtocolDefaultsTCP(t *testing.T) {
 	require.Len(t, result[0].Ports, 1)
 	require.NotNil(t, result[0].Ports[0].Protocol, "Protocol must not be nil when NP port omits protocol")
 	assert.Equal(t, corev1.ProtocolTCP, *result[0].Ports[0].Protocol)
+
+	t.Run("protocol-only entry (nil Port, nil Protocol) emits non-nil TCP", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockClient := mock_client.NewMockClient(ctrl)
+		resolver := NewEndpointsResolver(mockClient, logr.New(&log.NullLogSink{}))
+
+		protocolOnlyPorts := []networking.NetworkPolicyPort{
+			{},
+		}
+
+		svc := corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "svc2", Namespace: "ns"},
+			Spec: corev1.ServiceSpec{
+				ClusterIP: "10.0.0.2",
+				Selector:  map[string]string{"app": "web"},
+				Ports: []corev1.ServicePort{
+					{Port: 80, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(80)},
+				},
+			},
+		}
+
+		mockClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.ServiceList{}), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+				list.(*corev1.ServiceList).Items = []corev1.Service{svc}
+				return nil
+			})
+
+		result := resolver.getMatchingServiceClusterIPs(context.Background(), ls, "ns", protocolOnlyPorts)
+		require.Len(t, result, 1)
+		require.Len(t, result[0].Ports, 1)
+		require.NotNil(t, result[0].Ports[0].Protocol, "protocol-only entry must emit non-nil Protocol")
+		assert.Equal(t, corev1.ProtocolTCP, *result[0].Ports[0].Protocol)
+		assert.Nil(t, result[0].Ports[0].Port, "protocol-only entry must have nil Port")
+	})
 }
 
 func TestEndpointsResolver_getPortList(t *testing.T) {


### PR DESCRIPTION
 ### What this PR does

Fixes a nil-pointer dereference panic in getPortList (pkg/resolvers/endpoints.go) that crash-loops the controller when a policy rule contains a port entry with protocol omitted.

 ### Issue
  
NetworkPolicyPort.Protocol is *corev1.Protocol and optional — per the K8s API spec, a nil protocol should default to TCP. PR #237 (released in v1.1.9) added a nil guard in convertToPolicyInfoPortForCIDRs, but missed getPortList, which still dereferences *port.Protocol unguarded:
```
  portVal, _, err := k8s.LookupContainerPortAndName(&pod, *port.Port, *port.Protocol)
  //                                            panics when Protocol is nil ^^^^^^^^^^

  getPortList is on the named-port resolution path, reached from both:
  - egress: computeEgressEndpoints → getPortList (per destination pod)
  - ingress: resolveIngressPorts → getIngressRulesPorts → getPortList
```
  Any rule with a port entry whose protocol is nil crashes the controller with SIGSEGV, causing CrashLoopBackOff. Because the offending policy persists, the controller crash-loops indefinitely. 
Note: native networking.k8s.io/v1 NetworkPolicy objects get protocol: TCP defaulted by the API server at admission, but ApplicationNetworkPolicy (CRD) has no such defaulting — nil Protocol reaches the resolver directly.
```
  panic: runtime error: invalid memory address or nil pointer dereference

  goroutine 292 [running]:
  ...(*defaultEndpointsResolver).getPortList(...)
        /workspace/pkg/resolvers/endpoints.go:360 +0x17a
  ...(*defaultEndpointsResolver).Resolve.func2()
        /workspace/pkg/resolvers/endpoints.go:64 +0x69
```
  ### Fix

  Applies the same nil-guard pattern as PR #237:

  1. getPortList — default protocol to TCP when port.Protocol is nil, pass the defaulted value to LookupContainerPortAndName, and emit Protocol: &protocol (always non-nil) in the output policyinfo.Port so nil no longer propagates downstream.
  2. getMatchingServiceClusterIPs — hardening: hoisted the existing npProto TCP-default above the if npPort.Port != nil block and emit Protocol: &npProto in output. The dereference here was already guarded (no panic), but the output re-propagated the caller's nil Protocol into PolicyEndpoints.

  A full-repo scan for unguarded *.Protocol / *.Port / *.EndPort dereferences confirmed these are the last remaining sites — all other dereferences (dedupPorts, isNumericPortAllowed, equality/hashing code, ANP/CNP resolvers) are already nil-guarded.

### Testing

  Unit tests (all passing, incl. -race)
  
  - TestEndpointsResolver_getPortList (new, 8 table cases): nil Protocol + named port, nil Protocol + numeric port, nil Protocol + nil Port
  (protocol-only), explicit TCP/UDP controls, mixed list (named+TCP followed by numeric nil-protocol), multiple nil-Protocol entries. Verified RED on
  unfixed code (panics at endpoints.go:360 with the exact production stack trace) → GREEN with the fix.
  - TestEndpointsResolver_convertToPolicyInfoPortForCIDRs (new, 7 table cases): pins the PR #237 fix with direct regression tests (previously only covered
  indirectly).
  - TestGetMatchingServiceClusterIPs_NilProtocolDefaultsTCP (new): asserts service ClusterIP endpoint ports carry non-nil TCP-defaulted Protocol when the
  NP port omits protocol, including the protocol-only entry (nil Port + nil Protocol) case. Verified RED on unfixed code → GREEN with the fix.
  - Full existing suite passes: go build ./..., go vet ./..., gofmt clean, go test ./..., go test -race.

  Cluster verification (EKS, NPC on dataplane)

  Built two images: one from the v1.1.9 tag (unfixed) and one from this branch, and ran before/after on a live cluster with fixture pods (backend exposing named port http, web exposing named metrics + numeric 8443, scraper):

```  ┌───────────────────────────────────────────────────────────┬───────────────────────────────────────────────────────────────┬───────────────────────┐
  │          Repro policy (ApplicationNetworkPolicy)          │                            v1.1.9                             │       This fix        │
  ├───────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┼───────────────────────┤
  │ Egress, named port, protocol omitted                      │ ❌ panic at endpoints.go:360 via Resolve.func2 (matches       │ ✅ reconciles, 0      │
  │                                                           │ production stack)                                             │ restarts              │
  ├───────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┼───────────────────────┤
  │ Ingress, named port, protocol omitted                     │ ❌ panic at endpoints.go:360 via Resolve.func1 →              │ ✅ reconciles, 0      │
  │                                                           │ getIngressRulesPorts                                          │ restarts              │
  ├───────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┼───────────────────────┤
  │ Mixed rule (named+TCP entry, numeric entry with protocol  │ ❌ panic at endpoints.go:360                                  │ ✅ reconciles, 0      │
  │ omitted)                                                  │                                                               │ restarts              │
  ├───────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┼───────────────────────┤
  │ Regression: NP egress ipBlock CIDR, protocol omitted (PR  │ ✅ no panic                                                   │ ✅ reconciles, 0      │
  │ #237 path)                                                │                                                               │ restarts              │
  └───────────────────────────────────────────────────────────┴───────────────────────────────────────────────────────────────┴───────────────────────┘
```
  With the fixed image, all four policies were also applied simultaneously — zero restarts over the observation window, logs clean of panics, and PolicyEndpoints show the TCP-defaulted protocol on resolved ports.

  Behavior changes

  - Port entries with omitted protocol now resolve with TCP (per K8s spec) instead of crashing.
  - policyinfo.Port.Protocol emitted by getPortList and getMatchingServiceClusterIPs is now always non-nil (TCP-defaulted). This matches what the PolicyEndpoints CRD already defaults on write (default: TCP), and removes a latent nil-vs-TCP semantic-equality diff on protocol-only entries.


```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.