### PR TITLE
perf: resolve CNP egress rule peers with a single Resolve call

### DIFF
--- a/pkg/resolvers/clusternetworkpolicy_resolver.go
+++ b/pkg/resolvers/clusternetworkpolicy_resolver.go
@@ -273,55 +273,55 @@ func (r *clusterNetworkPolicyEndpointsResolver) resolveCNPEgressRules(ctx contex
 	}
 
 	for _, rule := range cnp.Spec.Egress {
+		// The temp NP embeds all of the rule's CIDR/Namespace/Pod peers, so a
+		// single Resolve() call covers the whole peer set. Skip Resolve for
+		// rules without such peers: an empty To list would be treated as
+		// "allow all" and emit spurious 0.0.0.0/0 + ::/0 endpoints.
+		if egressRuleHasResolvablePeer(rule) {
+			tempNP := r.convertSingleCNPEgressRuleToNP(cnp, rule, subjectNamespace)
+			_, egressEndpoints, _, err := r.baseResolver.Resolve(ctx, tempNP)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, endpoint := range egressEndpoints {
+				endpointInfos = append(endpointInfos, policyinfo.ClusterEndpointInfo{
+					CIDR:   endpoint.CIDR,
+					Ports:  endpoint.Ports,
+					Action: rule.Action,
+				})
+			}
+		}
+
+		// DomainNames are not part of the upstream NetworkPolicy schema, so
+		// baseResolver.Resolve cannot handle them; emit them directly.
 		for _, peer := range rule.To {
-			// Handle each peer type exclusively
-			if len(peer.Networks) > 0 {
-				// CIDR peer - namespace is irrelevant for CIDR resolution
-				tempNP := r.convertSingleCNPEgressRuleToNP(cnp, rule, subjectNamespace)
-				_, cidrEgressEndpoints, _, err := r.baseResolver.Resolve(ctx, tempNP)
-				if err != nil {
-					return nil, err
-				}
-
-				for _, endpoint := range cidrEgressEndpoints {
+			for _, domain := range peer.DomainNames {
+				if rule.Action == policyinfo.ClusterNetworkPolicyRuleActionAccept ||
+					rule.Action == policyinfo.ClusterNetworkPolicyRuleActionPass {
 					endpointInfos = append(endpointInfos, policyinfo.ClusterEndpointInfo{
-						CIDR:   endpoint.CIDR,
-						Ports:  endpoint.Ports,
-						Action: rule.Action,
+						DomainName: domain,
+						Action:     rule.Action,
+						Ports:      r.convertCNPPortsToEndpointPorts(rule.Ports),
 					})
 				}
-			} else if peer.Namespaces != nil || peer.Pods != nil {
-				tempNP := r.convertSingleCNPEgressRuleToNP(cnp, rule, subjectNamespace)
-				_, egressEndpoints, _, err := r.baseResolver.Resolve(ctx, tempNP)
-				if err != nil {
-					return nil, err
-				}
-
-				for _, endpoint := range egressEndpoints {
-					endpointInfos = append(endpointInfos, policyinfo.ClusterEndpointInfo{
-						CIDR:   endpoint.CIDR,
-						Ports:  endpoint.Ports,
-						Action: rule.Action,
-					})
-				}
-			} else if len(peer.DomainNames) > 0 {
-				// Domain name peer - handle directly
-				for _, domain := range peer.DomainNames {
-					if rule.Action == policyinfo.ClusterNetworkPolicyRuleActionAccept ||
-						rule.Action == policyinfo.ClusterNetworkPolicyRuleActionPass {
-						endpointInfos = append(endpointInfos, policyinfo.ClusterEndpointInfo{
-							DomainName: domain,
-							Action:     rule.Action,
-							Ports:      r.convertCNPPortsToEndpointPorts(rule.Ports),
-						})
-					}
-					// Ignore Deny action for domainNames as it's not supported
-				}
+				// Ignore Deny action for domainNames as it's not supported
 			}
 		}
 	}
 
 	return r.mergeClusterEndpointInfo(endpointInfos), nil
+}
+
+// egressRuleHasResolvablePeer reports whether an egress rule has at least one
+// peer that baseResolver.Resolve can handle (CIDR, Namespaces, or Pods).
+func egressRuleHasResolvablePeer(rule policyinfo.ClusterNetworkPolicyEgressRule) bool {
+	for _, peer := range rule.To {
+		if len(peer.Networks) > 0 || peer.Namespaces != nil || peer.Pods != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // convertSingleCNPIngressRuleToNP builds a temporary NetworkPolicy that wraps a

--- a/pkg/resolvers/clusternetworkpolicy_resolver_test.go
+++ b/pkg/resolvers/clusternetworkpolicy_resolver_test.go
@@ -1233,6 +1233,84 @@ func TestResolveCNPEgressRules_SingleResolveCallForNamespacePeer(t *testing.T) {
 	mockResolver.AssertNumberOfCalls(t, "Resolve", 1)
 }
 
+// TestResolveCNPEgressRules_SingleResolveCallForMultiplePeers verifies that a
+// rule with multiple CIDR/Namespace/Pod peers issues exactly one Resolve()
+// call, and that DomainName peers are handled directly without one.
+func TestResolveCNPEgressRules_SingleResolveCallForMultiplePeers(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = networking.AddToScheme(scheme)
+	_ = policyinfo.AddToScheme(scheme)
+
+	subjectNS := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "subject-ns", Labels: map[string]string{"role": "subject"}},
+	}
+	prodNS := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "prod-ns", Labels: map[string]string{"env": "prod"}},
+	}
+	devNS := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "dev-ns", Labels: map[string]string{"env": "dev"}},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(subjectNS, prodNS, devNS).
+		Build()
+
+	mockResolver := new(MockEndpointsResolver)
+	resolver := &clusterNetworkPolicyEndpointsResolver{
+		k8sClient:    fakeClient,
+		baseResolver: mockResolver,
+		logger:       logr.Discard(),
+	}
+
+	mockResolver.On("Resolve", mock.Anything, mock.Anything).Return(
+		[]policyinfo.EndpointInfo(nil),
+		[]policyinfo.EndpointInfo{{CIDR: "10.0.0.1"}},
+		[]policyinfo.PodEndpoint(nil),
+		nil,
+	)
+
+	cnp := &policyinfo.ClusterNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		Spec: policyinfo.ClusterNetworkPolicySpec{
+			Subject: policyinfo.ClusterNetworkPolicySubject{
+				Namespaces: &metav1.LabelSelector{MatchLabels: map[string]string{"role": "subject"}},
+			},
+			Egress: []policyinfo.ClusterNetworkPolicyEgressRule{
+				{
+					Name:   "multi-peer",
+					Action: policyinfo.ClusterNetworkPolicyRuleActionAccept,
+					To: []policyinfo.ClusterNetworkPolicyEgressPeer{
+						{Networks: []policyinfo.CIDR{"10.0.0.0/8"}},
+						{Namespaces: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}}},
+						{Namespaces: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "dev"}}},
+						{DomainNames: []policyinfo.DomainName{"example.com"}},
+					},
+				},
+			},
+		},
+	}
+
+	endpoints, err := resolver.resolveCNPEgressRules(context.Background(), cnp)
+	assert.NoError(t, err)
+	// 4 peers (1 CIDR + 2 NS + 1 DomainName) in a single rule → exactly 1
+	// Resolve() call.
+	mockResolver.AssertNumberOfCalls(t, "Resolve", 1)
+
+	// The single Resolve() result and the directly handled DomainName peer
+	// must both survive into the merged output.
+	assert.Len(t, endpoints, 2)
+	assert.Contains(t, endpoints, policyinfo.ClusterEndpointInfo{
+		CIDR:   "10.0.0.1",
+		Action: policyinfo.ClusterNetworkPolicyRuleActionAccept,
+	})
+	assert.Contains(t, endpoints, policyinfo.ClusterEndpointInfo{
+		DomainName: "example.com",
+		Action:     policyinfo.ClusterNetworkPolicyRuleActionAccept,
+	})
+}
+
 // Covers getSubjectNamespace for Pods/Namespaces subject + no-match cases.
 func TestGetSubjectNamespace(t *testing.T) {
 	scheme := runtime.NewScheme()


### PR DESCRIPTION
## Summary

`resolveCNPEgressRules` called `baseResolver.Resolve()` once per CIDR/Namespace/Pod peer of an egress rule, but the temp NetworkPolicy built by `convertSingleCNPEgressRuleToNP` already embeds **all** of the rule's resolvable peers. Each per-peer call therefore re-resolved the identical peer set, giving O(N^2) work for a rule with N peers and an N-times-oversized intermediate slice before `mergeClusterEndpointInfo` collapsed the duplicates.

### Changes
- Resolve all CIDR/Namespace/Pod peers of an egress rule with a single `Resolve()` call per rule.
- Skip `Resolve()` entirely for rules whose peers are all DomainNames — the resulting empty `To` list would be treated as allow-all and emit spurious `0.0.0.0/0` and `::/0` endpoints. DomainName peers are still emitted directly, unchanged.
- Add `egressRuleHasResolvablePeer` helper.

The merged output is unchanged: the previous redundant results were deduplicated by `mergeClusterEndpointInfo`.

### Testing
- New test `TestResolveCNPEgressRules_SingleResolveCallForMultiplePeers` asserts a rule with 4 peers (1 CIDR + 2 Namespace + 1 DomainName) issues exactly one `Resolve()` call and produces the expected CIDR and domain endpoints.
- Existing table tests cover domain-only rules (no spurious allow-all CIDRs) and mixed CIDR + domain rules.
- `go build ./...`, `go vet`, and `go test ./pkg/resolvers/...` pass.

Scale test

```

  ┌─────────┬─────────────────┬─────────────────┬──────────────────┐
  │ N peers │    Baseline     │ Fixed (f7ba9eb) │     Speedup      │
  ├─────────┼─────────────────┼─────────────────┼──────────────────┤
  │       5 │           0.18s │          0.046s │             3.9× │
  ├─────────┼─────────────────┼─────────────────┼──────────────────┤
  │      20 │           2.94s │          0.174s │              17× │
  ├─────────┼─────────────────┼─────────────────┼──────────────────┤
  │      40 │           11.7s │          0.351s │              33× │
  ├─────────┼─────────────────┼─────────────────┼──────────────────┤
  │      60 │           26.3s │          0.539s │              49× │
  ├─────────┼─────────────────┼─────────────────┼──────────────────┤
  │      80 │ OOMKilled (1Gi) │          0.686s │ crash → survives │
  └─────────┴─────────────────┴─────────────────┴──────────────────┘

  What resolver processed per reconcile

  N peers × 5 namespaces × ~932–988 pods, each peer's selector matching all pods.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.