### PR TITLE
Document podSelector limitation from #224

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ kubectl get deployment amazon-network-policy-controller-k8s -n kube-system | gre
 kubectl get deployment amazon-network-policy-controller-k8s -n kube-system
 kubectl logs deployment/amazon-network-policy-controller-k8s -n kube-system
 ```
+## Considerations
+
+### NetworkPolicy `podSelector` must match the target Service's selector
+
+When a pod reaches another pod through its Service ClusterIP, the network policy controller resolves the traffic through the Service IP (pre-DNAT). To allow this traffic with a NetworkPolicy, the `podSelector` in the policy must select pods using the **same labels the Service uses in its `spec.selector`**.
+
+Pods often carry several labels, and a Service may select them by only one of those labels. If a NetworkPolicy targets the pod using a *different* label than the one the Service selects on, traffic sent to the ClusterIP is not matched and is denied, even though the label technically matches the destination pod. Traffic sent directly to the pod IP is unaffected. See [issue #224](https://github.com/aws/amazon-network-policy-controller-k8s/issues/224) for background.
 
 ## Security Disclosures 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
-->
**What type of PR is this?** documentation

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**: #224


**What does this PR do / Why do we need it**: Document unsupported behavior with selecting label in NP that is not selected on in Service. This will lead to pod IPs allowed, service IPs not allowed.


**If an issue # is not available please add steps to reproduce and the controller logs**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!--
List the e2e tests you added as part of this PR.
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new K8s API
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.