### PR TITLE
fix: make PolicyEndpoint rule-identity hashes injective

### DIFF
--- a/charts/amazon-network-policy-controller-k8s/templates/rbac.yaml
+++ b/charts/amazon-network-policy-controller-k8s/templates/rbac.yaml
@@ -116,6 +116,47 @@ rules:
   - patch
   - update
 - apiGroups:
+  - networking.k8s.aws
+  resources:
+  - clusterpolicyendpoints
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.aws
+  resources:
+  - clusterpolicyendpoints/finalizers
+  - clusternetworkpolicies/finalizers
+  - applicationnetworkpolicies/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - networking.k8s.aws
+  resources:
+  - clusterpolicyendpoints/status
+  - clusternetworkpolicies/status
+  - applicationnetworkpolicies/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.aws
+  resources:
+  - clusternetworkpolicies
+  - applicationnetworkpolicies
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - networking.k8s.io
   resources:
   - networkpolicies

--- a/pkg/policyendpoints/clusterpolicyendpoints_chunking.go
+++ b/pkg/policyendpoints/clusterpolicyendpoints_chunking.go
@@ -3,6 +3,7 @@ package policyendpoints
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 
 	"github.com/samber/lo"
 	"golang.org/x/exp/maps"
@@ -60,7 +61,10 @@ func (m *policyEndpointsManager) processExistingClusterPolicyEndpoints(
 		ingEndpointList := make([]policyinfo.ClusterEndpointInfo, 0, len(existingCPEs[i].Spec.Ingress))
 		for _, ingRule := range existingCPEs[i].Spec.Ingress {
 			ruleKey := m.getClusterEndpointInfoKey(ingRule)
-			if _, exists := ingressEndpointsMap[ruleKey]; exists {
+			// Digest selects a candidate; DeepEqual decides equality so a stale
+			// stored rule is dropped even if it ever shares a digest with a
+			// different desired rule.
+			if desired, exists := ingressEndpointsMap[ruleKey]; exists && equality.Semantic.DeepEqual(desired, ingRule) {
 				ingEndpointList = append(ingEndpointList, ingRule)
 				delete(ingressEndpointsMap, ruleKey)
 			}
@@ -70,7 +74,7 @@ func (m *policyEndpointsManager) processExistingClusterPolicyEndpoints(
 		egEndpointList := make([]policyinfo.ClusterEndpointInfo, 0, len(existingCPEs[i].Spec.Egress))
 		for _, egRule := range existingCPEs[i].Spec.Egress {
 			ruleKey := m.getClusterEndpointInfoKey(egRule)
-			if _, exists := egressEndpointsMap[ruleKey]; exists {
+			if desired, exists := egressEndpointsMap[ruleKey]; exists && equality.Semantic.DeepEqual(desired, egRule) {
 				egEndpointList = append(egEndpointList, egRule)
 				delete(egressEndpointsMap, ruleKey)
 			}
@@ -277,22 +281,20 @@ func (m *policyEndpointsManager) getClusterEndpointInfoFromHashes(hashes []strin
 	return ruleList
 }
 
-// getClusterEndpointInfoKey generates a hash key for ClusterEndpointInfo
+// getClusterEndpointInfoKey generates a hash key for ClusterEndpointInfo.
+// Every field is written delimited and self-describing. The previous encoding
+// concatenated fields with no separator AND rendered ports with
+// string(rune(port)) (the Unicode code point, not the decimal text), so
+// different rules could collide silently. "field=value|" framing with decimal
+// ports removes both problems.
 func (m *policyEndpointsManager) getClusterEndpointInfoKey(info policyinfo.ClusterEndpointInfo) string {
 	hasher := sha256.New()
-	hasher.Write([]byte(string(info.CIDR)))
-	hasher.Write([]byte(string(info.DomainName)))
-	hasher.Write([]byte(string(info.Action)))
+	fmt.Fprintf(hasher, "cidr=%s|domainName=%s|action=%s|", info.CIDR, info.DomainName, info.Action)
 	for _, port := range info.Ports {
-		if port.Protocol != nil {
-			hasher.Write([]byte(string(*port.Protocol)))
-		}
-		if port.Port != nil {
-			hasher.Write([]byte(string(rune(*port.Port))))
-		}
-		if port.EndPort != nil {
-			hasher.Write([]byte(string(rune(*port.EndPort))))
-		}
+		fmt.Fprintf(hasher, "proto=%s|port=%s|endPort=%s|",
+			protocolKeyPart(port.Protocol),
+			int32PtrKeyPart(port.Port),
+			int32PtrKeyPart(port.EndPort))
 	}
 	return hex.EncodeToString(hasher.Sum(nil))
 }

--- a/pkg/policyendpoints/hash_collision_test.go
+++ b/pkg/policyendpoints/hash_collision_test.go
@@ -1,0 +1,133 @@
+package policyendpoints
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+
+	policyinfo "github.com/aws/amazon-network-policy-controller-k8s/api/v1alpha1"
+)
+
+// Regression tests for V2339293193: a separator-free rule-identity hash let
+// the controller treat two semantically different rules as one. Narrowing a
+// NetworkPolicy from the port range 1-23 to the single port 123 produced the
+// same digest, so the controller kept the revoked range and dropped the newly
+// declared port.
+
+func i32(v int32) *int32 { return &v }
+
+func Test_getEndpointInfoKey_portRangeVsSinglePort_noCollision(t *testing.T) {
+	m := &policyEndpointsManager{}
+	tcp := corev1.ProtocolTCP
+
+	// {TCP, port 1, endPort 23} -- the port RANGE 1-23
+	rangeRule := policyinfo.EndpointInfo{
+		CIDR:  "10.0.0.0/24",
+		Ports: []policyinfo.Port{{Protocol: &tcp, Port: i32(1), EndPort: i32(23)}},
+	}
+	// {TCP, port 123} -- a single port whose digits concatenate to the range's
+	singleRule := policyinfo.EndpointInfo{
+		CIDR:  "10.0.0.0/24",
+		Ports: []policyinfo.Port{{Protocol: &tcp, Port: i32(123)}},
+	}
+
+	assert.NotEqual(t, m.getEndpointInfoKey(rangeRule), m.getEndpointInfoKey(singleRule),
+		"range 1-23 and single port 123 must not share a hash key")
+}
+
+func Test_getEndpointInfoKey_deterministicAndDistinct(t *testing.T) {
+	m := &policyEndpointsManager{}
+	tcp := corev1.ProtocolTCP
+
+	base := policyinfo.EndpointInfo{
+		CIDR:  "10.0.0.0/24",
+		Ports: []policyinfo.Port{{Protocol: &tcp, Port: i32(80)}},
+	}
+	// same input -> same key
+	assert.Equal(t, m.getEndpointInfoKey(base), m.getEndpointInfoKey(base))
+
+	// a nil port must not collide with port 0 (the "nil" sentinel guards this)
+	nilPort := policyinfo.EndpointInfo{CIDR: "10.0.0.0/24", Ports: []policyinfo.Port{{Protocol: &tcp}}}
+	zeroPort := policyinfo.EndpointInfo{CIDR: "10.0.0.0/24", Ports: []policyinfo.Port{{Protocol: &tcp, Port: i32(0)}}}
+	assert.NotEqual(t, m.getEndpointInfoKey(nilPort), m.getEndpointInfoKey(zeroPort),
+		"absent port and port 0 must be distinguishable")
+
+	// CIDR boundary that a separator-free hash would blur:
+	// {cidr 10.0.0.0/2, except 4} vs {cidr 10.0.0.0/24}
+	a := policyinfo.EndpointInfo{CIDR: "10.0.0.0/2", Except: []policyinfo.NetworkAddress{"4"}}
+	b := policyinfo.EndpointInfo{CIDR: "10.0.0.0/24"}
+	assert.NotEqual(t, m.getEndpointInfoKey(a), m.getEndpointInfoKey(b))
+}
+
+func Test_getClusterEndpointInfoKey_portRangeVsSinglePort_noCollision(t *testing.T) {
+	m := &policyEndpointsManager{}
+	tcp := corev1.ProtocolTCP
+
+	rangeRule := policyinfo.ClusterEndpointInfo{
+		CIDR:   "10.0.0.0/24",
+		Action: policyinfo.ClusterNetworkPolicyRuleActionAccept,
+		Ports:  []policyinfo.Port{{Protocol: &tcp, Port: i32(1), EndPort: i32(23)}},
+	}
+	singleRule := policyinfo.ClusterEndpointInfo{
+		CIDR:   "10.0.0.0/24",
+		Action: policyinfo.ClusterNetworkPolicyRuleActionAccept,
+		Ports:  []policyinfo.Port{{Protocol: &tcp, Port: i32(123)}},
+	}
+
+	assert.NotEqual(t, m.getClusterEndpointInfoKey(rangeRule), m.getClusterEndpointInfoKey(singleRule),
+		"CNP range 1-23 and single port 123 must not share a hash key")
+}
+
+// The previous CNP key used string(rune(port)), the Unicode code point rather
+// than the decimal text. Ports 80 and 443 both had to encode distinctly; more
+// importantly, values that map to the same rune arithmetic must not collide.
+func Test_getClusterEndpointInfoKey_distinctPorts(t *testing.T) {
+	m := &policyEndpointsManager{}
+	tcp := corev1.ProtocolTCP
+
+	p80 := policyinfo.ClusterEndpointInfo{
+		CIDR:   "10.0.0.0/24",
+		Action: policyinfo.ClusterNetworkPolicyRuleActionAccept,
+		Ports:  []policyinfo.Port{{Protocol: &tcp, Port: i32(80)}},
+	}
+	p443 := policyinfo.ClusterEndpointInfo{
+		CIDR:   "10.0.0.0/24",
+		Action: policyinfo.ClusterNetworkPolicyRuleActionAccept,
+		Ports:  []policyinfo.Port{{Protocol: &tcp, Port: i32(443)}},
+	}
+	assert.NotEqual(t, m.getClusterEndpointInfoKey(p80), m.getClusterEndpointInfoKey(p443))
+
+	// Action must remain part of the identity: same CIDR/ports, different action.
+	deny := p80
+	deny.Action = policyinfo.ClusterNetworkPolicyRuleActionDeny
+	assert.NotEqual(t, m.getClusterEndpointInfoKey(p80), m.getClusterEndpointInfoKey(deny),
+		"differing Action must produce a different key")
+}
+
+// string(rune(n)) is not injective over the port range: every n in the UTF-16
+// surrogate block U+D800-U+DFFF (55296-57343) is not a valid rune, so Go
+// encodes all 2048 of them as the replacement character U+FFFD. Under the old
+// encoding every port in that block hashed identically, so changing a policy
+// from one such port to another was silently ignored.
+func Test_getClusterEndpointInfoKey_surrogateBlockPorts_noCollision(t *testing.T) {
+	m := &policyEndpointsManager{}
+	tcp := corev1.ProtocolTCP
+
+	cpe := func(port int32) policyinfo.ClusterEndpointInfo {
+		return policyinfo.ClusterEndpointInfo{
+			CIDR:   "10.0.0.0/24",
+			Action: policyinfo.ClusterNetworkPolicyRuleActionAccept,
+			Ports:  []policyinfo.Port{{Protocol: &tcp, Port: i32(port)}},
+		}
+	}
+
+	// Both ends of the surrogate block, plus an interior value.
+	for _, other := range []int32{55297, 57000, 57343} {
+		assert.NotEqual(t, m.getClusterEndpointInfoKey(cpe(55296)), m.getClusterEndpointInfoKey(cpe(other)),
+			"ports 55296 and %d must not share a hash key", other)
+	}
+
+	// A surrogate-block port must also stay distinct from a port outside it.
+	assert.NotEqual(t, m.getClusterEndpointInfoKey(cpe(55296)), m.getClusterEndpointInfoKey(cpe(40000)))
+}

--- a/pkg/policyendpoints/manager.go
+++ b/pkg/policyendpoints/manager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -409,29 +410,46 @@ func (m *policyEndpointsManager) getListOfEndpointInfoFromHash(hashes []string, 
 func (m *policyEndpointsManager) getEndpointInfoKey(info policyinfo.EndpointInfo) string {
 	hasher := sha256.New()
 
+	// Every field is written delimited and self-describing so that no two
+	// semantically different endpoints can produce the same byte stream. A bare
+	// concatenation (e.g. port "1" followed by endPort "23") is ambiguous with a
+	// single port "123"; the "field=value|" framing removes that ambiguity.
 	// Handle FQDN case for ApplicationNetworkPolicy
 	if info.DomainName != "" {
-		hasher.Write([]byte(info.DomainName))
+		fmt.Fprintf(hasher, "domainName=%s|", info.DomainName)
 	} else {
 		// Handle CIDR case for NetworkPolicy
-		hasher.Write([]byte(info.CIDR))
+		fmt.Fprintf(hasher, "cidr=%s|", info.CIDR)
 		for _, except := range info.Except {
-			hasher.Write([]byte(except))
+			fmt.Fprintf(hasher, "except=%s|", except)
 		}
 	}
 
 	for _, port := range info.Ports {
-		if port.Protocol != nil {
-			hasher.Write([]byte(*port.Protocol))
-		}
-		if port.Port != nil {
-			hasher.Write([]byte(strconv.Itoa(int(*port.Port))))
-		}
-		if port.EndPort != nil {
-			hasher.Write([]byte(strconv.Itoa(int(*port.EndPort))))
-		}
+		fmt.Fprintf(hasher, "proto=%s|port=%s|endPort=%s|",
+			protocolKeyPart(port.Protocol),
+			int32PtrKeyPart(port.Port),
+			int32PtrKeyPart(port.EndPort))
 	}
 	return hex.EncodeToString(hasher.Sum(nil))
+}
+
+// protocolKeyPart renders a protocol pointer for hashing, using "nil" for an
+// absent value so a missing protocol is distinguishable from any real one.
+func protocolKeyPart(p *corev1.Protocol) string {
+	if p == nil {
+		return "nil"
+	}
+	return string(*p)
+}
+
+// int32PtrKeyPart renders an int32 pointer for hashing, using "nil" for an
+// absent value so a missing port is distinguishable from port 0.
+func int32PtrKeyPart(p *int32) string {
+	if p == nil {
+		return "nil"
+	}
+	return strconv.Itoa(int(*p))
 }
 
 // processExistingPolicyEndpoints processes the existing policies with the incoming policy changes
@@ -472,7 +490,12 @@ func (m *policyEndpointsManager) processExistingPolicyEndpoints(
 		ingEndpointList := make([]policyinfo.EndpointInfo, 0, len(existingPolicyEndpoints[i].Spec.Ingress))
 		for _, ingRule := range existingPolicyEndpoints[i].Spec.Ingress {
 			ruleKey := m.getEndpointInfoKey(ingRule)
-			if _, exists := ingressEndpointsMap[ruleKey]; exists {
+			// The digest only selects a candidate. A hit is treated as "keep the
+			// stored rule" only when the stored and desired rules are actually
+			// equal; otherwise the stored rule is stale and is left out so the
+			// desired rule (still in the map) gets written. This makes the result
+			// correct even if two different rules ever share a digest.
+			if desired, exists := ingressEndpointsMap[ruleKey]; exists && equality.Semantic.DeepEqual(desired, ingRule) {
 				ingEndpointList = append(ingEndpointList, ingRule)
 				delete(ingressEndpointsMap, ruleKey)
 			}
@@ -480,7 +503,7 @@ func (m *policyEndpointsManager) processExistingPolicyEndpoints(
 		egEndpointList := make([]policyinfo.EndpointInfo, 0, len(existingPolicyEndpoints[i].Spec.Egress))
 		for _, egRule := range existingPolicyEndpoints[i].Spec.Egress {
 			ruleKey := m.getEndpointInfoKey(egRule)
-			if _, exists := egressEndpointsMap[ruleKey]; exists {
+			if desired, exists := egressEndpointsMap[ruleKey]; exists && equality.Semantic.DeepEqual(desired, egRule) {
 				egEndpointList = append(egEndpointList, egRule)
 				delete(egressEndpointsMap, ruleKey)
 			}


### PR DESCRIPTION
## What

Fixes two non-injective rule-identity hashes in `pkg/policyendpoints`, and one unrelated chart RBAC gap found while testing the fix on a live cluster.

## Why

`getEndpointInfoKey` and `getClusterEndpointInfoKey` produce the digest that `processExistingPolicyEndpoints` / `processExistingClusterPolicyEndpoints` use as their **sole** equality test when deciding whether a rule already stored on a `(Cluster)PolicyEndpoint` still satisfies the desired policy:

```go
ruleKey := m.getEndpointInfoKey(ingRule)
if _, exists := ingressEndpointsMap[ruleKey]; exists {
    ingEndpointList = append(ingEndpointList, ingRule) // keep the STORED rule
    delete(ingressEndpointsMap, ruleKey)               // drop the DESIRED rule
}
```

If two semantically different rules share a digest, the controller keeps the stale stored rule and discards the newly desired one. The `(Cluster)PolicyEndpoint` is then never rewritten — its `resourceVersion` freezes while the policy's `generation` advances — so the node agent keeps programming eBPF from a rule the user already revoked. Nothing errors and nothing is logged.

Both encodings were non-injective, for two independent reasons.

### 1. Separator-free concatenation (`getEndpointInfoKey`, namespaced path)

Fields were concatenated with no delimiter and ports rendered as decimal text:

```go
hasher.Write([]byte(strconv.Itoa(int(*port.Port))))
hasher.Write([]byte(strconv.Itoa(int(*port.EndPort))))
```

So `{port: 1, endPort: 23}` and `{port: 123}` hash identically — narrowing a policy from the range `1-23` to the single port `123` is silently ignored, and so is widening back. Same ambiguity class for `CIDR`/`Except` and for `{80, 8080}` vs `{8080, 80}`.

### 2. `string(rune(port))` (`getClusterEndpointInfoKey`, cluster path)

```go
hasher.Write([]byte(string(rune(*port.Port))))
```

This writes the Unicode code point, not the decimal text. That mapping is not injective over the port range: every value in the UTF-16 surrogate block **U+D800–U+DFFF (55296–57343)** is an invalid rune and encodes to the replacement character U+FFFD. All **2048** ports in that block hash identically.

Worth noting these are *different* bugs. The cluster path does not share the digit-concatenation collision (code points are fixed-width, so they are prefix-free); it has its own, arguably wider, collision class.

## How

Both key functions now write every field delimited and self-describing, ports in decimal:

```go
fmt.Fprintf(hasher, "cidr=%s|", info.CIDR)
fmt.Fprintf(hasher, "proto=%s|port=%s|endPort=%s|",
    protocolKeyPart(port.Protocol),
    int32PtrKeyPart(port.Port),
    int32PtrKeyPart(port.EndPort))
```

`protocolKeyPart` / `int32PtrKeyPart` emit an explicit `"nil"` for absent pointers, so a missing port stays distinguishable from port `0` and a missing protocol from any real protocol. Previously an absent field wrote nothing at all, which was itself a collision source.

**Defence in depth.** The digest now only *selects a candidate*. Both reuse gates additionally require the stored and desired rule to actually be equal before the stored rule is kept:

```go
if desired, exists := ingressEndpointsMap[ruleKey]; exists && equality.Semantic.DeepEqual(desired, ingRule) {
```

On a digest hit with unequal rules, the stored rule is left out of the kept list and the desired rule stays in the map, so it gets written. Correctness no longer depends on the hash being perfect.

## Upgrade behaviour — no migration needed

Because the digest now covers every field of the struct rather than a subset, existing `(Cluster)PolicyEndpoint` objects carrying stale rules are rewritten on the first reconcile after upgrade. On startup the informer's initial LIST produces `Create` events, `enqueueRequestForPolicyEvent.Create` enqueues unconditionally, `SetupWithManager` registers no watch predicates, and `reconcile` calls `reconcileNetworkPolicy` unconditionally — so every policy is recomputed once at controller start. Verified empirically below.

Caveat: healing is tied specifically to **controller start**. The `Update` handler short-circuits when the spec is unchanged, so a long-running controller will not spontaneously re-derive keys for an untouched policy. Deleting `PolicyEndpoint` objects to force a rebuild is *not* a safe alternative — it opens an enforcement gap until they are recreated.

## Second, unrelated fix: chart ClusterRole

The chart's `ClusterRole` was never regenerated after `ClusterNetworkPolicy` / `ApplicationNetworkPolicy` support landed. It grants only `policyendpoints`, while `config/rbac/role.yaml` and the kubebuilder markers at `internal/controllers/policy_controller.go:90-95` require `clusternetworkpolicies`, `clusterpolicyendpoints` and `applicationnetworkpolicies` plus their `/status` and `/finalizers` subresources.

The failure mode is silent and total:

```
failed to list *v1alpha1.ClusterPolicyEndpoint: clusterpolicyendpoints.networking.k8s.aws is forbidden
failed to list *v1alpha1.ApplicationNetworkPolicy: applicationnetworkpolicies.networking.k8s.aws is forbidden
```

`WaitForCacheSync` never completes for those informers, so the manager starts **no controllers at all** — while the Deployment reports Ready and `kubectl rollout status` succeeds. A chart-based controller reconciles nothing, with only reflector warnings to show it.

Related and **not** fixed here: `scripts/deploy-controller-on-dataplane.sh` passes `--set useExistingClusterRole=true`, but nothing in `charts/` reads `useExistingClusterRole` or `clusterRole`. The chart always creates its own `ClusterRole` and binds to it, shadowing the managed `eks:network-policy-controller` role which already carries every needed rule. Worth a follow-up: either implement the value or drop the flag.

## Testing

### Unit

`pkg/policyendpoints/hash_collision_test.go`, all failing before this change and passing after:

| Test | Guards |
|---|---|
| `Test_getEndpointInfoKey_portRangeVsSinglePort_noCollision` | `{1, endPort 23}` vs `{123}` |
| `Test_getEndpointInfoKey_deterministicAndDistinct` | determinism; absent port vs port `0`; `{cidr /2, except 4}` vs `{cidr /24}` |
| `Test_getClusterEndpointInfoKey_portRangeVsSinglePort_noCollision` | cluster range vs single port |
| `Test_getClusterEndpointInfoKey_distinctPorts` | `80` vs `443`; `Accept` vs `Deny` |
| `Test_getClusterEndpointInfoKey_surrogateBlockPorts_noCollision` | `55296` vs `55297` / `57000` / `57343`, and vs `40000` outside the block |

Collisions under the old encoding were confirmed directly by re-implementing it standalone:

```
cluster OLD: 55296 vs 55297 collide=true
cluster OLD: 55296 vs 57000 collide=true
cluster OLD: 55296 vs 57343 collide=true
cluster OLD: 55296 vs 40000 collide=false   <- control, correctly distinct
ns      OLD: {1,23} vs {123}  collide=true
```

`go build ./...`, `go vet ./pkg/...`, `gofmt -l`, `go test ./...` and `helm template` are all clean.

### On a live EKS dev cluster

Built this branch into an image and deployed it to the dataplane with `scripts/deploy-controller-on-dataplane.sh` (both new digest format strings verified present in the compiled binary).

**Baseline — the bug, on the unpatched controller.** A `NetworkPolicy` was created with `{TCP port 1, endPort 23}`, then narrowed to `{TCP port 123}`:

| | `PolicyEndpoint` rv | stored rule | policy declares |
|---|---|---|---|
| after narrow | `15070982` | `{TCP port 123}` | `{TCP 1-23}` |
| +5 min | `15070982` (frozen) | `{TCP port 123}` | `{TCP 1-23}` |

Frozen indefinitely in both directions (narrow and widen), while the policy's `generation` advanced to 5. A control policy using port `124` — which has no colliding partner — propagated in under 30s, confirming the controller was otherwise healthy.

**Self-heal on controller start.** With that stale object left in place, the patched controller was started. No policy edit was made — `generation` stayed at 5 throughout:

| | `PolicyEndpoint` rv | stored rule |
|---|---|---|
| before | `15070982` | `{TCP port 123}` |
| after patched controller started | `15134169` | `{TCP port 1, endPort 23}` ✅ |

The stale object converged on its own, from the startup reconcile alone. This is what the "no migration needed" claim above rests on.

**Regression checks on the patched controller** — each previously frozen indefinitely, each now applied within 10s:

| Change | Result |
|---|---|
| narrow `1-23` → `123` | applied, rv `15134544` |
| widen `123` → `1-23` | applied, rv `15134836` |
| `ClusterNetworkPolicy` port `55296` → `57000` (both U+FFFD before) | applied, rv `15135035` |

**Chart RBAC.** Before the RBAC commit, the deploy script produced a Ready 2/2 Deployment that reconciled nothing — the stale `PolicyEndpoint` above stayed frozen at `15070982` even under the patched controller, because no controller had started. After granting the three missing resources, `forbidden` log lines dropped to zero and reconciliation resumed immediately. That is how the RBAC gap was found.

## Risk

Every existing `(Cluster)PolicyEndpoint` gets its rule keys recomputed on first reconcile after upgrade, so objects whose stored rules disagree with their policy will be rewritten once. That is the intended correction, not churn: the new digest is a pure function of the fields already present, so objects that already agree with their policy hash consistently and are left untouched.
