### PR TITLE
fix: make PolicyEndpoint rule-identity hashes injective

### DIFF
--- a/charts/amazon-network-policy-controller-k8s/templates/rbac.yaml
+++ b/charts/amazon-network-policy-controller-k8s/templates/rbac.yaml
@@ -116,6 +116,47 @@ rules:
   - patch
   - update
 - apiGroups:
+  - networking.k8s.aws
+  resources:
+  - clusterpolicyendpoints
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.aws
+  resources:
+  - clusterpolicyendpoints/finalizers
+  - clusternetworkpolicies/finalizers
+  - applicationnetworkpolicies/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - networking.k8s.aws
+  resources:
+  - clusterpolicyendpoints/status
+  - clusternetworkpolicies/status
+  - applicationnetworkpolicies/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.aws
+  resources:
+  - clusternetworkpolicies
+  - applicationnetworkpolicies
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - networking.k8s.io
   resources:
   - networkpolicies

--- a/pkg/policyendpoints/clusterpolicyendpoints_chunking.go
+++ b/pkg/policyendpoints/clusterpolicyendpoints_chunking.go
@@ -3,6 +3,7 @@ package policyendpoints
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 
 	"github.com/samber/lo"
 	"golang.org/x/exp/maps"
@@ -60,7 +61,10 @@ func (m *policyEndpointsManager) processExistingClusterPolicyEndpoints(
 		ingEndpointList := make([]policyinfo.ClusterEndpointInfo, 0, len(existingCPEs[i].Spec.Ingress))
 		for _, ingRule := range existingCPEs[i].Spec.Ingress {
 			ruleKey := m.getClusterEndpointInfoKey(ingRule)
-			if _, exists := ingressEndpointsMap[ruleKey]; exists {
+			// Digest selects a candidate; DeepEqual decides equality so a stale
+			// stored rule is dropped even if it ever shares a digest with a
+			// different desired rule.
+			if desired, exists := ingressEndpointsMap[ruleKey]; exists && equality.Semantic.DeepEqual(desired, ingRule) {
 				ingEndpointList = append(ingEndpointList, ingRule)
 				delete(ingressEndpointsMap, ruleKey)
 			}
@@ -70,7 +74,7 @@ func (m *policyEndpointsManager) processExistingClusterPolicyEndpoints(
 		egEndpointList := make([]policyinfo.ClusterEndpointInfo, 0, len(existingCPEs[i].Spec.Egress))
 		for _, egRule := range existingCPEs[i].Spec.Egress {
 			ruleKey := m.getClusterEndpointInfoKey(egRule)
-			if _, exists := egressEndpointsMap[ruleKey]; exists {
+			if desired, exists := egressEndpointsMap[ruleKey]; exists && equality.Semantic.DeepEqual(desired, egRule) {
 				egEndpointList = append(egEndpointList, egRule)
 				delete(egressEndpointsMap, ruleKey)
 			}
@@ -277,22 +281,20 @@ func (m *policyEndpointsManager) getClusterEndpointInfoFromHashes(hashes []strin
 	return ruleList
 }
 
-// getClusterEndpointInfoKey generates a hash key for ClusterEndpointInfo
+// getClusterEndpointInfoKey generates a hash key for ClusterEndpointInfo.
+// Every field is written delimited and self-describing. The previous encoding
+// concatenated fields with no separator AND rendered ports with
+// string(rune(port)) (the Unicode code point, not the decimal text), so
+// different rules could collide silently. "field=value|" framing with decimal
+// ports removes both problems.
 func (m *policyEndpointsManager) getClusterEndpointInfoKey(info policyinfo.ClusterEndpointInfo) string {
 	hasher := sha256.New()
-	hasher.Write([]byte(string(info.CIDR)))
-	hasher.Write([]byte(string(info.DomainName)))
-	hasher.Write([]byte(string(info.Action)))
+	fmt.Fprintf(hasher, "cidr=%s|domainName=%s|action=%s|", info.CIDR, info.DomainName, info.Action)
 	for _, port := range info.Ports {
-		if port.Protocol != nil {
-			hasher.Write([]byte(string(*port.Protocol)))
-		}
-		if port.Port != nil {
-			hasher.Write([]byte(string(rune(*port.Port))))
-		}
-		if port.EndPort != nil {
-			hasher.Write([]byte(string(rune(*port.EndPort))))
-		}
+		fmt.Fprintf(hasher, "proto=%s|port=%s|endPort=%s|",
+			protocolKeyPart(port.Protocol),
+			int32PtrKeyPart(port.Port),
+			int32PtrKeyPart(port.EndPort))
 	}
 	return hex.EncodeToString(hasher.Sum(nil))
 }

--- a/pkg/policyendpoints/hash_collision_test.go
+++ b/pkg/policyendpoints/hash_collision_test.go
@@ -9,8 +9,8 @@ import (
 	policyinfo "github.com/aws/amazon-network-policy-controller-k8s/api/v1alpha1"
 )
 
-// Regression tests for V2339293193: a separator-free rule-identity hash let
-// the controller treat two semantically different rules as one. Narrowing a
+// Regression tests for a rule-identity hash collision: a separator-free hash
+// let the controller treat two semantically different rules as one. Narrowing a
 // NetworkPolicy from the port range 1-23 to the single port 123 produced the
 // same digest, so the controller kept the revoked range and dropped the newly
 // declared port.

--- a/pkg/policyendpoints/hash_collision_test.go
+++ b/pkg/policyendpoints/hash_collision_test.go
@@ -1,0 +1,133 @@
+package policyendpoints
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+
+	policyinfo "github.com/aws/amazon-network-policy-controller-k8s/api/v1alpha1"
+)
+
+// Regression tests for V2339293193: a separator-free rule-identity hash let
+// the controller treat two semantically different rules as one. Narrowing a
+// NetworkPolicy from the port range 1-23 to the single port 123 produced the
+// same digest, so the controller kept the revoked range and dropped the newly
+// declared port.
+
+func i32(v int32) *int32 { return &v }
+
+func Test_getEndpointInfoKey_portRangeVsSinglePort_noCollision(t *testing.T) {
+	m := &policyEndpointsManager{}
+	tcp := corev1.ProtocolTCP
+
+	// {TCP, port 1, endPort 23} -- the port RANGE 1-23
+	rangeRule := policyinfo.EndpointInfo{
+		CIDR:  "10.0.0.0/24",
+		Ports: []policyinfo.Port{{Protocol: &tcp, Port: i32(1), EndPort: i32(23)}},
+	}
+	// {TCP, port 123} -- a single port whose digits concatenate to the range's
+	singleRule := policyinfo.EndpointInfo{
+		CIDR:  "10.0.0.0/24",
+		Ports: []policyinfo.Port{{Protocol: &tcp, Port: i32(123)}},
+	}
+
+	assert.NotEqual(t, m.getEndpointInfoKey(rangeRule), m.getEndpointInfoKey(singleRule),
+		"range 1-23 and single port 123 must not share a hash key")
+}
+
+func Test_getEndpointInfoKey_deterministicAndDistinct(t *testing.T) {
+	m := &policyEndpointsManager{}
+	tcp := corev1.ProtocolTCP
+
+	base := policyinfo.EndpointInfo{
+		CIDR:  "10.0.0.0/24",
+		Ports: []policyinfo.Port{{Protocol: &tcp, Port: i32(80)}},
+	}
+	// same input -> same key
+	assert.Equal(t, m.getEndpointInfoKey(base), m.getEndpointInfoKey(base))
+
+	// a nil port must not collide with port 0 (the "nil" sentinel guards this)
+	nilPort := policyinfo.EndpointInfo{CIDR: "10.0.0.0/24", Ports: []policyinfo.Port{{Protocol: &tcp}}}
+	zeroPort := policyinfo.EndpointInfo{CIDR: "10.0.0.0/24", Ports: []policyinfo.Port{{Protocol: &tcp, Port: i32(0)}}}
+	assert.NotEqual(t, m.getEndpointInfoKey(nilPort), m.getEndpointInfoKey(zeroPort),
+		"absent port and port 0 must be distinguishable")
+
+	// CIDR boundary that a separator-free hash would blur:
+	// {cidr 10.0.0.0/2, except 4} vs {cidr 10.0.0.0/24}
+	a := policyinfo.EndpointInfo{CIDR: "10.0.0.0/2", Except: []policyinfo.NetworkAddress{"4"}}
+	b := policyinfo.EndpointInfo{CIDR: "10.0.0.0/24"}
+	assert.NotEqual(t, m.getEndpointInfoKey(a), m.getEndpointInfoKey(b))
+}
+
+func Test_getClusterEndpointInfoKey_portRangeVsSinglePort_noCollision(t *testing.T) {
+	m := &policyEndpointsManager{}
+	tcp := corev1.ProtocolTCP
+
+	rangeRule := policyinfo.ClusterEndpointInfo{
+		CIDR:   "10.0.0.0/24",
+		Action: policyinfo.ClusterNetworkPolicyRuleActionAccept,
+		Ports:  []policyinfo.Port{{Protocol: &tcp, Port: i32(1), EndPort: i32(23)}},
+	}
+	singleRule := policyinfo.ClusterEndpointInfo{
+		CIDR:   "10.0.0.0/24",
+		Action: policyinfo.ClusterNetworkPolicyRuleActionAccept,
+		Ports:  []policyinfo.Port{{Protocol: &tcp, Port: i32(123)}},
+	}
+
+	assert.NotEqual(t, m.getClusterEndpointInfoKey(rangeRule), m.getClusterEndpointInfoKey(singleRule),
+		"CNP range 1-23 and single port 123 must not share a hash key")
+}
+
+// The previous CNP key used string(rune(port)), the Unicode code point rather
+// than the decimal text. Ports 80 and 443 both had to encode distinctly; more
+// importantly, values that map to the same rune arithmetic must not collide.
+func Test_getClusterEndpointInfoKey_distinctPorts(t *testing.T) {
+	m := &policyEndpointsManager{}
+	tcp := corev1.ProtocolTCP
+
+	p80 := policyinfo.ClusterEndpointInfo{
+		CIDR:   "10.0.0.0/24",
+		Action: policyinfo.ClusterNetworkPolicyRuleActionAccept,
+		Ports:  []policyinfo.Port{{Protocol: &tcp, Port: i32(80)}},
+	}
+	p443 := policyinfo.ClusterEndpointInfo{
+		CIDR:   "10.0.0.0/24",
+		Action: policyinfo.ClusterNetworkPolicyRuleActionAccept,
+		Ports:  []policyinfo.Port{{Protocol: &tcp, Port: i32(443)}},
+	}
+	assert.NotEqual(t, m.getClusterEndpointInfoKey(p80), m.getClusterEndpointInfoKey(p443))
+
+	// Action must remain part of the identity: same CIDR/ports, different action.
+	deny := p80
+	deny.Action = policyinfo.ClusterNetworkPolicyRuleActionDeny
+	assert.NotEqual(t, m.getClusterEndpointInfoKey(p80), m.getClusterEndpointInfoKey(deny),
+		"differing Action must produce a different key")
+}
+
+// string(rune(n)) is not injective over the port range: every n in the UTF-16
+// surrogate block U+D800-U+DFFF (55296-57343) is not a valid rune, so Go
+// encodes all 2048 of them as the replacement character U+FFFD. Under the old
+// encoding every port in that block hashed identically, so changing a policy
+// from one such port to another was silently ignored.
+func Test_getClusterEndpointInfoKey_surrogateBlockPorts_noCollision(t *testing.T) {
+	m := &policyEndpointsManager{}
+	tcp := corev1.ProtocolTCP
+
+	cpe := func(port int32) policyinfo.ClusterEndpointInfo {
+		return policyinfo.ClusterEndpointInfo{
+			CIDR:   "10.0.0.0/24",
+			Action: policyinfo.ClusterNetworkPolicyRuleActionAccept,
+			Ports:  []policyinfo.Port{{Protocol: &tcp, Port: i32(port)}},
+		}
+	}
+
+	// Both ends of the surrogate block, plus an interior value.
+	for _, other := range []int32{55297, 57000, 57343} {
+		assert.NotEqual(t, m.getClusterEndpointInfoKey(cpe(55296)), m.getClusterEndpointInfoKey(cpe(other)),
+			"ports 55296 and %d must not share a hash key", other)
+	}
+
+	// A surrogate-block port must also stay distinct from a port outside it.
+	assert.NotEqual(t, m.getClusterEndpointInfoKey(cpe(55296)), m.getClusterEndpointInfoKey(cpe(40000)))
+}

--- a/pkg/policyendpoints/manager.go
+++ b/pkg/policyendpoints/manager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -409,29 +410,46 @@ func (m *policyEndpointsManager) getListOfEndpointInfoFromHash(hashes []string, 
 func (m *policyEndpointsManager) getEndpointInfoKey(info policyinfo.EndpointInfo) string {
 	hasher := sha256.New()
 
+	// Every field is written delimited and self-describing so that no two
+	// semantically different endpoints can produce the same byte stream. A bare
+	// concatenation (e.g. port "1" followed by endPort "23") is ambiguous with a
+	// single port "123"; the "field=value|" framing removes that ambiguity.
 	// Handle FQDN case for ApplicationNetworkPolicy
 	if info.DomainName != "" {
-		hasher.Write([]byte(info.DomainName))
+		fmt.Fprintf(hasher, "domainName=%s|", info.DomainName)
 	} else {
 		// Handle CIDR case for NetworkPolicy
-		hasher.Write([]byte(info.CIDR))
+		fmt.Fprintf(hasher, "cidr=%s|", info.CIDR)
 		for _, except := range info.Except {
-			hasher.Write([]byte(except))
+			fmt.Fprintf(hasher, "except=%s|", except)
 		}
 	}
 
 	for _, port := range info.Ports {
-		if port.Protocol != nil {
-			hasher.Write([]byte(*port.Protocol))
-		}
-		if port.Port != nil {
-			hasher.Write([]byte(strconv.Itoa(int(*port.Port))))
-		}
-		if port.EndPort != nil {
-			hasher.Write([]byte(strconv.Itoa(int(*port.EndPort))))
-		}
+		fmt.Fprintf(hasher, "proto=%s|port=%s|endPort=%s|",
+			protocolKeyPart(port.Protocol),
+			int32PtrKeyPart(port.Port),
+			int32PtrKeyPart(port.EndPort))
 	}
 	return hex.EncodeToString(hasher.Sum(nil))
+}
+
+// protocolKeyPart renders a protocol pointer for hashing, using "nil" for an
+// absent value so a missing protocol is distinguishable from any real one.
+func protocolKeyPart(p *corev1.Protocol) string {
+	if p == nil {
+		return "nil"
+	}
+	return string(*p)
+}
+
+// int32PtrKeyPart renders an int32 pointer for hashing, using "nil" for an
+// absent value so a missing port is distinguishable from port 0.
+func int32PtrKeyPart(p *int32) string {
+	if p == nil {
+		return "nil"
+	}
+	return strconv.Itoa(int(*p))
 }
 
 // processExistingPolicyEndpoints processes the existing policies with the incoming policy changes
@@ -472,7 +490,12 @@ func (m *policyEndpointsManager) processExistingPolicyEndpoints(
 		ingEndpointList := make([]policyinfo.EndpointInfo, 0, len(existingPolicyEndpoints[i].Spec.Ingress))
 		for _, ingRule := range existingPolicyEndpoints[i].Spec.Ingress {
 			ruleKey := m.getEndpointInfoKey(ingRule)
-			if _, exists := ingressEndpointsMap[ruleKey]; exists {
+			// The digest only selects a candidate. A hit is treated as "keep the
+			// stored rule" only when the stored and desired rules are actually
+			// equal; otherwise the stored rule is stale and is left out so the
+			// desired rule (still in the map) gets written. This makes the result
+			// correct even if two different rules ever share a digest.
+			if desired, exists := ingressEndpointsMap[ruleKey]; exists && equality.Semantic.DeepEqual(desired, ingRule) {
 				ingEndpointList = append(ingEndpointList, ingRule)
 				delete(ingressEndpointsMap, ruleKey)
 			}
@@ -480,7 +503,7 @@ func (m *policyEndpointsManager) processExistingPolicyEndpoints(
 		egEndpointList := make([]policyinfo.EndpointInfo, 0, len(existingPolicyEndpoints[i].Spec.Egress))
 		for _, egRule := range existingPolicyEndpoints[i].Spec.Egress {
 			ruleKey := m.getEndpointInfoKey(egRule)
-			if _, exists := egressEndpointsMap[ruleKey]; exists {
+			if desired, exists := egressEndpointsMap[ruleKey]; exists && equality.Semantic.DeepEqual(desired, egRule) {
 				egEndpointList = append(egEndpointList, egRule)
 				delete(egressEndpointsMap, ruleKey)
 			}


### PR DESCRIPTION
## Problem

`getEndpointInfoKey` / `getClusterEndpointInfoKey` produce the digest that `processExistingPolicyEndpoints` / `processExistingClusterPolicyEndpoints` use as their **only** equality test for reusing a rule already stored on a `(Cluster)PolicyEndpoint`:

```go
ruleKey := m.getEndpointInfoKey(ingRule)
if _, exists := ingressEndpointsMap[ruleKey]; exists {
    ingEndpointList = append(ingEndpointList, ingRule) // keep STORED rule
    delete(ingressEndpointsMap, ruleKey)               // drop DESIRED rule
}
```

On a digest collision the controller keeps the stale rule and discards the desired one. The object is then never rewritten — `resourceVersion` freezes while the policy's `generation` advances — so the node agent keeps enforcing a revoked rule. Nothing errors, nothing logs.

Both encodings were non-injective, for two unrelated reasons:

1. **Separator-free concatenation** (namespaced path). Fields ran together and ports were decimal text, so `{port: 1, endPort: 23}` and `{port: 123}` hash identically. Narrowing `1-23` → `123` is silently ignored; so is widening back. Same class for `CIDR`/`Except` and `{80, 8080}` vs `{8080, 80}`.

2. **`string(rune(port))`** (cluster path) writes the code point, not the decimal text. Every value in the UTF-16 surrogate block **U+D800–U+DFFF (55296–57343)** is an invalid rune and encodes to U+FFFD, so all **2048** ports there hash identically.

These are different bugs. The cluster path does *not* share the digit collision — code points are fixed-width, hence prefix-free — it has its own, wider one.

## Fix

Every field is written delimited and self-describing, ports in decimal:

```go
fmt.Fprintf(hasher, "proto=%s|port=%s|endPort=%s|",
    protocolKeyPart(port.Protocol), int32PtrKeyPart(port.Port), int32PtrKeyPart(port.EndPort))
```

Helpers emit `"nil"` for absent pointers, keeping a missing port distinct from port `0`. Previously an absent field wrote nothing, itself a collision source.

**Defence in depth:** the digest now only *selects a candidate*. Both reuse gates also require the rules to actually match, so correctness no longer depends on the hash being perfect:

```go
if desired, exists := ingressEndpointsMap[ruleKey]; exists && equality.Semantic.DeepEqual(desired, ingRule) {
```

## Upgrade: no migration needed

The digest now covers every field rather than a subset, so stale objects are rewritten on the first reconcile after upgrade: the informer's initial LIST fires `Create` events, `enqueueRequestForPolicyEvent.Create` enqueues unconditionally, `SetupWithManager` registers no predicates, and `reconcile` calls `reconcileNetworkPolicy` unconditionally.

Caveat: this is tied to controller **start**. `Update` short-circuits on unchanged spec, so a long-running controller won't re-derive keys for an untouched policy. Deleting `PolicyEndpoint`s to force a rebuild is *not* a safe alternative — it opens an enforcement gap.

## Second, unrelated fix: chart ClusterRole

The chart's `ClusterRole` was never regenerated after `ClusterNetworkPolicy` / `ApplicationNetworkPolicy` landed. It grants only `policyendpoints`, while `config/rbac/role.yaml` and the markers at `internal/controllers/policy_controller.go:90-95` require `clusternetworkpolicies`, `clusterpolicyendpoints`, `applicationnetworkpolicies` and their `/status`, `/finalizers`.

Failure mode is silent and total: those informers get `forbidden`, `WaitForCacheSync` never completes, and the manager starts **no controllers at all** — while the Deployment reports Ready and `kubectl rollout status` succeeds.

Not fixed here: `scripts/deploy-controller-on-dataplane.sh` passes `--set useExistingClusterRole=true`, but nothing in `charts/` reads it. The chart always creates its own `ClusterRole` and binds to it, shadowing the managed `eks:network-policy-controller` role that already has every rule. Follow-up: implement the value or drop the flag.

## Testing

**Unit** — `pkg/policyendpoints/hash_collision_test.go`, all failing before this change:

| Test | Guards |
|---|---|
| `..._portRangeVsSinglePort_noCollision` (both paths) | `{1, endPort 23}` vs `{123}` |
| `Test_getEndpointInfoKey_deterministicAndDistinct` | determinism; absent port vs `0`; `{cidr /2, except 4}` vs `{cidr /24}` |
| `Test_getClusterEndpointInfoKey_distinctPorts` | `80` vs `443`; `Accept` vs `Deny` |
| `..._surrogateBlockPorts_noCollision` | `55296` vs `55297`/`57000`/`57343`, and vs `40000` |

Old-encoding collisions confirmed by re-implementing it standalone:

```
cluster OLD: 55296 vs 55297 collide=true
cluster OLD: 55296 vs 57000 collide=true
cluster OLD: 55296 vs 57343 collide=true
cluster OLD: 55296 vs 40000 collide=false   <- control, correctly distinct
ns      OLD: {1,23} vs {123}  collide=true
```

`go build ./...`, `go vet ./pkg/...`, `gofmt -l`, `go test ./...`, `helm template` all clean.

**Live EKS dev cluster** — this branch built into an image and deployed to the dataplane via `scripts/deploy-controller-on-dataplane.sh`.

*Baseline, unpatched:* editing the policy's port block between `{TCP 123}` and `{TCP 1-23}` froze its `PolicyEndpoint` in **both** directions — the stale rule was reused every time. At the point captured below the policy declared `{TCP 1-23}` at `generation=5`, while the `PolicyEndpoint` was still holding the superseded `{TCP port 123}` at `rv=15070982`, unchanged 5 min later: five accepted spec versions, zero downstream writes. A control policy on port `124` (no colliding partner) propagated in <30s, confirming the controller was otherwise healthy.

*Self-heal on start:* with that stale object left in place, the patched controller was started. No policy edit — `generation` stayed 5:

| | rv | stored rule |
|---|---|---|
| before | `15070982` | `{TCP port 123}` |
| after start | `15134169` | `{TCP port 1, endPort 23}` ✅ |

*Regression checks*, each previously frozen indefinitely, now applied within 10s:

| Change | Result |
|---|---|
| narrow `1-23` → `123` | rv `15134544` |
| widen `123` → `1-23` | rv `15134836` |
| CNP port `55296` → `57000` (both U+FFFD before) | rv `15135035` |

**End-to-end traffic enforcement.** The above confirms the controller writes the right object; this confirms packets actually follow it. Two busybox pods in namespace `nptraffic` — `server` listening on TCP 22 and 123, `client` probing with `nc -w 3` — under a policy admitting only `172.31.0.0/16`. Same chart (RBAC fix included) for both runs, so the only variable is the controller binary.

| Policy declares | Controller | `PolicyEndpoint` stores | port 22 | port 123 |
|---|---|---|---|---|
| `TCP 1-23` | unpatched | `1-23` | ALLOW | DENY |
| `TCP 123` | unpatched | `1-23` (frozen, rv `15367688`) | **ALLOW** ⚠️ | **DENY** ⚠️ |
| `TCP 123` | patched, *no policy edit* | `123` (rv `15368576`) | DENY ✅ | ALLOW ✅ |
| `TCP 1-23` | patched | `1-23` (rv `15368767`) | ALLOW ✅ | DENY ✅ |

Row 2 is the impact in one line: `generation` had advanced to 2 declaring **only** port 123, yet port 22 stayed reachable for over 2 minutes — a revoked port still admitting traffic — while port 123, explicitly allowed, was dropped. Both a policy bypass and an availability break, from one digest collision.

Row 3 is self-heal at the traffic layer: no policy edit, only the patched controller starting.

Denies were confirmed to be eBPF **drops** rather than connection refusals, by timing (~1.2s of each figure is fixed `kubectl exec` overhead):

| probe | policy | listener | elapsed |
|---|---|---|---|
| port 22 | allows | yes | 1245ms — connects |
| port 21 | allows | **no** | 1171ms — instant RST, refused |
| port 123 | denies | yes | 4199ms — full `nc -w 3` timeout, dropped |

Port 21 is the control that matters: permitted by the policy but with nothing listening, it refuses immediately. So the extra 3s on port 123 is the dataplane discarding packets, not a missing listener.

*Chart RBAC:* before that commit the deploy script yielded a Ready 2/2 Deployment that reconciled nothing — the stale object stayed at `15070982` even under the patched controller. Granting the three resources dropped `forbidden` lines to zero and reconciliation resumed. That's how the gap was found.

## Risk

All existing `(Cluster)PolicyEndpoint`s get keys recomputed on first reconcile, so any whose stored rules disagree with their policy are rewritten once. That's the intended correction, not churn — the digest is a pure function of existing fields, so objects already in agreement hash consistently and are left untouched.
