### PR TITLE
Make policy endpoint hash keys unambiguous

### DIFF
--- a/pkg/policyendpoints/clusterpolicyendpoints_chunking.go
+++ b/pkg/policyendpoints/clusterpolicyendpoints_chunking.go
@@ -1,9 +1,6 @@
 package policyendpoints
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
-
 	"github.com/samber/lo"
 	"golang.org/x/exp/maps"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -57,11 +54,12 @@ func (m *policyEndpointsManager) processExistingClusterPolicyEndpoints(
 	// Process existing CPEs (following the same logic as regular PE processing)
 	for i := range existingCPEs {
 		// Filter ingress rules - keep only those that exist in the new rules
+		// Keep the desired copy; a key match need not imply equality.
 		ingEndpointList := make([]policyinfo.ClusterEndpointInfo, 0, len(existingCPEs[i].Spec.Ingress))
 		for _, ingRule := range existingCPEs[i].Spec.Ingress {
 			ruleKey := m.getClusterEndpointInfoKey(ingRule)
-			if _, exists := ingressEndpointsMap[ruleKey]; exists {
-				ingEndpointList = append(ingEndpointList, ingRule)
+			if desired, exists := ingressEndpointsMap[ruleKey]; exists {
+				ingEndpointList = append(ingEndpointList, *desired.DeepCopy())
 				delete(ingressEndpointsMap, ruleKey)
 			}
 		}
@@ -70,8 +68,8 @@ func (m *policyEndpointsManager) processExistingClusterPolicyEndpoints(
 		egEndpointList := make([]policyinfo.ClusterEndpointInfo, 0, len(existingCPEs[i].Spec.Egress))
 		for _, egRule := range existingCPEs[i].Spec.Egress {
 			ruleKey := m.getClusterEndpointInfoKey(egRule)
-			if _, exists := egressEndpointsMap[ruleKey]; exists {
-				egEndpointList = append(egEndpointList, egRule)
+			if desired, exists := egressEndpointsMap[ruleKey]; exists {
+				egEndpointList = append(egEndpointList, *desired.DeepCopy())
 				delete(egressEndpointsMap, ruleKey)
 			}
 		}
@@ -102,11 +100,12 @@ func (m *policyEndpointsManager) processExistingClusterPolicyEndpoints(
 			existingCPEs[i].Spec.Egress = egEndpointList
 			existingCPEs[i].Spec.PodSelectorEndpoints = podSelectorEndpointList
 			potentialDeletes = append(potentialDeletes, existingCPEs[i])
-		} else if len(existingCPEs[i].Spec.Ingress) != len(ingEndpointList) ||
-			len(existingCPEs[i].Spec.Egress) != len(egEndpointList) ||
-			len(existingCPEs[i].Spec.PodSelectorEndpoints) != len(podSelectorEndpointList) ||
+		} else if !equality.Semantic.DeepEqual(existingCPEs[i].Spec.Ingress, ingEndpointList) ||
+			!equality.Semantic.DeepEqual(existingCPEs[i].Spec.Egress, egEndpointList) ||
+			!equality.Semantic.DeepEqual(existingCPEs[i].Spec.PodSelectorEndpoints, podSelectorEndpointList) ||
 			tierChanged || priorityChanged || subjectChanged {
-			// CPE has changed - update it
+			// CPE has changed - update it. Content, not length: an in-place
+			// edit keeps the count.
 			existingCPEs[i].Spec.Ingress = ingEndpointList
 			existingCPEs[i].Spec.Egress = egEndpointList
 			existingCPEs[i].Spec.PodSelectorEndpoints = podSelectorEndpointList
@@ -279,20 +278,10 @@ func (m *policyEndpointsManager) getClusterEndpointInfoFromHashes(hashes []strin
 
 // getClusterEndpointInfoKey generates a hash key for ClusterEndpointInfo
 func (m *policyEndpointsManager) getClusterEndpointInfoKey(info policyinfo.ClusterEndpointInfo) string {
-	hasher := sha256.New()
-	hasher.Write([]byte(string(info.CIDR)))
-	hasher.Write([]byte(string(info.DomainName)))
-	hasher.Write([]byte(string(info.Action)))
-	for _, port := range info.Ports {
-		if port.Protocol != nil {
-			hasher.Write([]byte(string(*port.Protocol)))
-		}
-		if port.Port != nil {
-			hasher.Write([]byte(string(rune(*port.Port))))
-		}
-		if port.EndPort != nil {
-			hasher.Write([]byte(string(rune(*port.EndPort))))
-		}
-	}
-	return hex.EncodeToString(hasher.Sum(nil))
+	w := newHashKeyWriter()
+	w.str("cidr", string(info.CIDR))
+	w.str("domain", string(info.DomainName))
+	w.str("action", string(info.Action))
+	w.ports(info.Ports)
+	return w.sum()
 }

--- a/pkg/policyendpoints/hashkey.go
+++ b/pkg/policyendpoints/hashkey.go
@@ -1,0 +1,118 @@
+package policyendpoints
+
+import (
+	"cmp"
+	"crypto/sha256"
+	"encoding/hex"
+	"slices"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+
+	policyinfo "github.com/aws/amazon-network-policy-controller-k8s/api/v1alpha1"
+)
+
+// hashKeyWriter builds injective hash input for endpoint keys: fields are tagged
+// and byte-length-prefixed, integers are decimal. A cluster rule encodes as
+//
+//	cidr=13:10.200.0.0/16;domain=0:;action=4:Deny;ports=1[proto=3:TCP;port=80;endport=nil;,];
+type hashKeyWriter struct {
+	buf []byte
+}
+
+func newHashKeyWriter() *hashKeyWriter {
+	return &hashKeyWriter{buf: make([]byte, 0, 128)}
+}
+
+func (w *hashKeyWriter) str(tag, val string) {
+	w.buf = append(w.buf, tag...)
+	w.buf = append(w.buf, '=')
+	w.buf = strconv.AppendInt(w.buf, int64(len(val)), 10)
+	w.buf = append(w.buf, ':')
+	w.buf = append(w.buf, val...)
+	w.buf = append(w.buf, ';')
+}
+
+func (w *hashKeyWriter) optInt32(tag string, val *int32) {
+	w.buf = append(w.buf, tag...)
+	w.buf = append(w.buf, '=')
+	if val == nil {
+		w.buf = append(w.buf, "nil;"...)
+		return
+	}
+	w.buf = strconv.AppendInt(w.buf, int64(*val), 10)
+	w.buf = append(w.buf, ';')
+}
+
+func (w *hashKeyWriter) strs(tag string, vals []policyinfo.NetworkAddress) {
+	sorted := vals
+	if !slices.IsSorted(vals) {
+		sorted = slices.Clone(vals)
+		slices.Sort(sorted)
+	}
+
+	w.buf = append(w.buf, tag...)
+	w.buf = append(w.buf, '=')
+	w.buf = strconv.AppendInt(w.buf, int64(len(sorted)), 10)
+	w.buf = append(w.buf, '[')
+	for _, v := range sorted {
+		w.str("v", string(v))
+	}
+	w.buf = append(w.buf, "];"...)
+}
+
+// ports hashes a canonical ordering; the caller's slice is not reordered.
+func (w *hashKeyWriter) ports(ports []policyinfo.Port) {
+	sorted := ports
+	if !slices.IsSortedFunc(ports, comparePorts) {
+		sorted = slices.Clone(ports)
+		slices.SortFunc(sorted, comparePorts)
+	}
+
+	w.buf = slices.Grow(w.buf, len(sorted)*48)
+	w.buf = append(w.buf, "ports="...)
+	w.buf = strconv.AppendInt(w.buf, int64(len(sorted)), 10)
+	w.buf = append(w.buf, '[')
+	for _, p := range sorted {
+		if p.Protocol != nil {
+			w.str("proto", string(*p.Protocol))
+		} else {
+			w.buf = append(w.buf, "proto=nil;"...)
+		}
+		w.optInt32("port", p.Port)
+		w.optInt32("endport", p.EndPort)
+		w.buf = append(w.buf, ',')
+	}
+	w.buf = append(w.buf, "];"...)
+}
+
+func (w *hashKeyWriter) sum() string {
+	sum := sha256.Sum256(w.buf)
+	return hex.EncodeToString(sum[:])
+}
+
+func comparePorts(a, b policyinfo.Port) int {
+	if c := strings.Compare(protoOrEmpty(a.Protocol), protoOrEmpty(b.Protocol)); c != 0 {
+		return c
+	}
+	if c := cmp.Compare(intOrNeg(a.Port), intOrNeg(b.Port)); c != 0 {
+		return c
+	}
+	return cmp.Compare(intOrNeg(a.EndPort), intOrNeg(b.EndPort))
+}
+
+func protoOrEmpty(p *corev1.Protocol) string {
+	if p == nil {
+		return ""
+	}
+	return string(*p)
+}
+
+// nil sorts ahead of every valid port.
+func intOrNeg(v *int32) int64 {
+	if v == nil {
+		return -1
+	}
+	return int64(*v)
+}

--- a/pkg/policyendpoints/hashkey_test.go
+++ b/pkg/policyendpoints/hashkey_test.go
@@ -1,0 +1,354 @@
+package policyendpoints
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	policyinfo "github.com/aws/amazon-network-policy-controller-k8s/api/v1alpha1"
+)
+
+func cnpInfo(port int32) policyinfo.ClusterEndpointInfo {
+	tcp, p := corev1.ProtocolTCP, port
+	return policyinfo.ClusterEndpointInfo{
+		CIDR: "10.200.0.0/16", Action: "Deny",
+		Ports: []policyinfo.Port{{Protocol: &tcp, Port: &p}},
+	}
+}
+
+func TestClusterKeyInjectiveOverPortSpace(t *testing.T) {
+	m := &policyEndpointsManager{}
+	seen := make(map[string]int32, 65535)
+	for p := int32(1); p <= 65535; p++ {
+		k := m.getClusterEndpointInfoKey(cnpInfo(p))
+		if prev, dup := seen[k]; dup {
+			t.Fatalf("ports %d and %d share a key", prev, p)
+		}
+		seen[k] = p
+	}
+	if len(seen) != 65535 {
+		t.Fatalf("got %d distinct keys, want 65535", len(seen))
+	}
+}
+
+func TestClusterKeyHighPortsDiffer(t *testing.T) {
+	m := &policyEndpointsManager{}
+	for _, tc := range [][2]int32{{55555, 56666}, {56666, 57000}, {55300, 57000}, {55555, 65535}} {
+		if m.getClusterEndpointInfoKey(cnpInfo(tc[0])) == m.getClusterEndpointInfoKey(cnpInfo(tc[1])) {
+			t.Errorf("ports %d and %d share a key", tc[0], tc[1])
+		}
+	}
+}
+
+func TestKeyFieldsCannotAlias(t *testing.T) {
+	m := &policyEndpointsManager{}
+	pairs := [][2]policyinfo.ClusterEndpointInfo{
+		{{CIDR: "10.0.0.0/8", DomainName: "", Action: "Deny"},
+			{CIDR: "10.0.0.0/", DomainName: "8", Action: "Deny"}},
+		{{CIDR: "10.0.0.0/8", Action: "Deny"},
+			{CIDR: "10.0.0.0/8De", Action: "ny"}},
+	}
+	for i, p := range pairs {
+		if m.getClusterEndpointInfoKey(p[0]) == m.getClusterEndpointInfoKey(p[1]) {
+			t.Errorf("pair %d aliases", i)
+		}
+	}
+}
+
+func TestNamespacedKeyPortRangesCannotAlias(t *testing.T) {
+	m := &policyEndpointsManager{}
+	rng := func(lo, hi int32) policyinfo.EndpointInfo {
+		tcp, l, h := corev1.ProtocolTCP, lo, hi
+		return policyinfo.EndpointInfo{
+			CIDR:  "10.200.0.0/16",
+			Ports: []policyinfo.Port{{Protocol: &tcp, Port: &l, EndPort: &h}},
+		}
+	}
+	for _, tc := range [][4]int32{{1, 234, 12, 34}, {1, 2345, 12, 345}} {
+		if m.getEndpointInfoKey(rng(tc[0], tc[1])) == m.getEndpointInfoKey(rng(tc[2], tc[3])) {
+			t.Errorf("ranges %d-%d and %d-%d share a key", tc[0], tc[1], tc[2], tc[3])
+		}
+	}
+
+	a := policyinfo.EndpointInfo{CIDR: "10.0.0.0/8", Except: []policyinfo.NetworkAddress{"10.1.0.0/16"}}
+	b := policyinfo.EndpointInfo{CIDR: "10.0.0.0/810.1.0.0/16"}
+	if m.getEndpointInfoKey(a) == m.getEndpointInfoKey(b) {
+		t.Error("CIDR absorbed an Except entry")
+	}
+}
+
+func TestKeyNilAndBoundaryPortFields(t *testing.T) {
+	m := &policyEndpointsManager{}
+	tcp, udp := corev1.ProtocolTCP, corev1.ProtocolUDP
+	one, max := int32(1), int32(65535)
+
+	protos := []*corev1.Protocol{nil, &tcp, &udp}
+	nums := []*int32{nil, &one, &max}
+
+	seen := map[string]policyinfo.Port{}
+	for _, proto := range protos {
+		for _, port := range nums {
+			for _, endPort := range nums {
+				p := policyinfo.Port{Protocol: proto, Port: port, EndPort: endPort}
+				info := policyinfo.ClusterEndpointInfo{
+					CIDR: "10.200.0.0/16", Action: "Deny",
+					Ports: []policyinfo.Port{p},
+				}
+				k := m.getClusterEndpointInfoKey(info)
+				if prev, dup := seen[k]; dup {
+					t.Errorf("%+v and %+v share a key", prev, p)
+				}
+				seen[k] = p
+				if again := m.getClusterEndpointInfoKey(info); again != k {
+					t.Errorf("%+v is not deterministic", p)
+				}
+			}
+		}
+	}
+	if len(seen) != len(protos)*len(nums)*len(nums) {
+		t.Fatalf("got %d distinct keys, want %d", len(seen), len(protos)*len(nums)*len(nums))
+	}
+
+	noPorts := policyinfo.ClusterEndpointInfo{CIDR: "10.200.0.0/16", Action: "Deny"}
+	emptyPorts := noPorts
+	emptyPorts.Ports = []policyinfo.Port{}
+	if m.getClusterEndpointInfoKey(noPorts) != m.getClusterEndpointInfoKey(emptyPorts) {
+		t.Error("nil and empty Ports should be equivalent")
+	}
+	if _, dup := seen[m.getClusterEndpointInfoKey(noPorts)]; dup {
+		t.Error("no ports collides with a single-port rule")
+	}
+}
+
+func TestKeyIgnoresFieldOrder(t *testing.T) {
+	m := &policyEndpointsManager{}
+	tcp, udp := corev1.ProtocolTCP, corev1.ProtocolUDP
+	p80, p443 := int32(80), int32(443)
+
+	a := []policyinfo.Port{
+		{Protocol: &tcp, Port: &p80},
+		{Protocol: &udp, Port: &p443},
+		{Protocol: &tcp},
+	}
+	b := []policyinfo.Port{a[2], a[1], a[0]}
+	infoA := policyinfo.ClusterEndpointInfo{CIDR: "10.200.0.0/16", Action: "Deny", Ports: a}
+	infoB := policyinfo.ClusterEndpointInfo{CIDR: "10.200.0.0/16", Action: "Deny", Ports: b}
+	if m.getClusterEndpointInfoKey(infoA) != m.getClusterEndpointInfoKey(infoB) {
+		t.Error("permuted ports produced different keys")
+	}
+	if a[0].Port != &p80 || a[2].Port != nil {
+		t.Error("caller's port slice was reordered")
+	}
+
+	exA := policyinfo.EndpointInfo{CIDR: "10.0.0.0/8",
+		Except: []policyinfo.NetworkAddress{"10.1.0.0/16", "10.2.0.0/16"}}
+	exB := policyinfo.EndpointInfo{CIDR: "10.0.0.0/8",
+		Except: []policyinfo.NetworkAddress{"10.2.0.0/16", "10.1.0.0/16"}}
+	if m.getEndpointInfoKey(exA) != m.getEndpointInfoKey(exB) {
+		t.Error("permuted Except produced different keys")
+	}
+	if exA.Except[0] != "10.1.0.0/16" {
+		t.Error("caller's Except slice was reordered")
+	}
+}
+
+func TestSubstitutedRuleIsIsolated(t *testing.T) {
+	m := &policyEndpointsManager{}
+	desired := cnpInfo(56666)
+	stored := []policyinfo.ClusterPolicyEndpoint{{
+		Spec: policyinfo.ClusterPolicyEndpointSpec{
+			Tier:   "Admin",
+			Egress: []policyinfo.ClusterEndpointInfo{cnpInfo(56666)},
+		},
+	}}
+
+	// A tier change forces the spec to be rebuilt from the desired rules.
+	_, _, _, modified, _ := m.processExistingClusterPolicyEndpoints(
+		stored, nil, []policyinfo.ClusterEndpointInfo{desired}, nil,
+		ClusterPolicyMetadata{Tier: "Baseline"})
+
+	if len(modified) != 1 || len(modified[0].Spec.Egress) != 1 {
+		t.Fatalf("expected one retained egress rule, got %+v", modified)
+	}
+	*modified[0].Spec.Egress[0].Ports[0].Port = 1
+	if *desired.Ports[0].Port != 56666 {
+		t.Error("mutating the persisted rule reached the desired rule")
+	}
+}
+
+func TestInPlacePortEditReachesCPE(t *testing.T) {
+	m := &policyEndpointsManager{endpointChunkSize: 100}
+	cnp := &policyinfo.ClusterNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cnp"},
+		Spec:       policyinfo.ClusterNetworkPolicySpec{Tier: "Admin", Priority: 10},
+	}
+	stored := []policyinfo.ClusterPolicyEndpoint{{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cnp-abc12"},
+		Spec: policyinfo.ClusterPolicyEndpointSpec{
+			PolicyRef: policyinfo.ClusterPolicyReference{Name: "test-cnp"},
+			Tier:      "Admin", Priority: 10,
+			Egress: []policyinfo.ClusterEndpointInfo{cnpInfo(55555)},
+		},
+	}}
+
+	create, update, _, err := m.computeClusterPolicyEndpoints(
+		cnp, stored, nil, []policyinfo.ClusterEndpointInfo{cnpInfo(56666)}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var ports []int32
+	for _, cpe := range append(append([]policyinfo.ClusterPolicyEndpoint{}, create...), update...) {
+		for _, e := range cpe.Spec.Egress {
+			ports = append(ports, *e.Ports[0].Port)
+		}
+	}
+	if len(ports) != 1 || ports[0] != 56666 {
+		t.Fatalf("persisted egress ports = %v, want [56666]", ports)
+	}
+}
+
+func TestKeyResistsSeparatorsAndMultibyteValues(t *testing.T) {
+	m := &policyEndpointsManager{}
+	long := strings.Repeat("x", 1500)
+	values := []string{
+		"", "a", "a;", ";a", "a=1", "=1:a;", "cidr=1:a;", "1:a", "a[b]", "a,b", "a];",
+		"\u65e5\u672c\u8a9e", "\u65e5", "\u00e9", "e\u0301", long, long + "y",
+	}
+
+	seen := map[string]string{}
+	add := func(label string, info policyinfo.EndpointInfo) {
+		k := m.getEndpointInfoKey(info)
+		if prev, dup := seen[k]; dup {
+			t.Errorf("%s collides with %s", label, prev)
+		}
+		seen[k] = label
+		if again := m.getEndpointInfoKey(info); again != k {
+			t.Errorf("%s is not deterministic", label)
+		}
+	}
+
+	for i, v := range values {
+		add(fmt.Sprintf("cidr[%d]", i), policyinfo.EndpointInfo{CIDR: policyinfo.NetworkAddress(v)})
+		add(fmt.Sprintf("except[%d]", i), policyinfo.EndpointInfo{
+			Except: []policyinfo.NetworkAddress{policyinfo.NetworkAddress(v)}})
+		if v != "" {
+			add(fmt.Sprintf("domain[%d]", i), policyinfo.EndpointInfo{DomainName: policyinfo.DomainName(v)})
+		}
+	}
+
+	nilExcept := policyinfo.EndpointInfo{CIDR: "10.0.0.0/8"}
+	emptyExcept := policyinfo.EndpointInfo{CIDR: "10.0.0.0/8", Except: []policyinfo.NetworkAddress{}}
+	if m.getEndpointInfoKey(nilExcept) != m.getEndpointInfoKey(emptyExcept) {
+		t.Error("nil and empty Except should be equivalent")
+	}
+}
+
+func TestDuplicateStoredRulesCollapse(t *testing.T) {
+	m := &policyEndpointsManager{}
+	rewriteTier := ClusterPolicyMetadata{Tier: "Baseline"}
+	mk := func(name string, rules ...policyinfo.ClusterEndpointInfo) policyinfo.ClusterPolicyEndpoint {
+		return policyinfo.ClusterPolicyEndpoint{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec:       policyinfo.ClusterPolicyEndpointSpec{Tier: "Admin", Egress: rules},
+		}
+	}
+	countEgress := func(sets ...[]policyinfo.ClusterPolicyEndpoint) int {
+		n := 0
+		for _, s := range sets {
+			for _, cpe := range s {
+				n += len(cpe.Spec.Egress)
+			}
+		}
+		return n
+	}
+
+	t.Run("within one object", func(t *testing.T) {
+		_, leftover, _, modified, deletes := m.processExistingClusterPolicyEndpoints(
+			[]policyinfo.ClusterPolicyEndpoint{mk("a", cnpInfo(80), cnpInfo(80))},
+			nil, []policyinfo.ClusterEndpointInfo{cnpInfo(80)}, nil, rewriteTier)
+
+		if got := countEgress(modified, deletes); got != 1 {
+			t.Errorf("egress rules retained = %d, want 1", got)
+		}
+		if len(leftover) != 0 {
+			t.Errorf("unplaced desired rules = %d, want 0", len(leftover))
+		}
+	})
+
+	t.Run("across two objects", func(t *testing.T) {
+		_, leftover, _, modified, deletes := m.processExistingClusterPolicyEndpoints(
+			[]policyinfo.ClusterPolicyEndpoint{mk("a", cnpInfo(80)), mk("b", cnpInfo(80))},
+			nil, []policyinfo.ClusterEndpointInfo{cnpInfo(80)}, nil, rewriteTier)
+
+		if got := countEgress(modified, deletes); got != 1 {
+			t.Errorf("egress rules retained = %d, want 1", got)
+		}
+		if len(leftover) != 0 {
+			t.Errorf("unplaced desired rules = %d, want 0", len(leftover))
+		}
+		if len(deletes) != 1 {
+			t.Fatalf("emptied objects = %d, want 1", len(deletes))
+		}
+		if deletes[0].Name != "b" {
+			t.Errorf("emptied object = %q, want \"b\"", deletes[0].Name)
+		}
+	})
+}
+
+func TestFQDNKeyCoversCIDRAndExcept(t *testing.T) {
+	m := &policyEndpointsManager{}
+	base := policyinfo.EndpointInfo{DomainName: "example.com"}
+
+	withCIDR := base
+	withCIDR.CIDR = "10.0.0.0/8"
+	otherCIDR := base
+	otherCIDR.CIDR = "192.168.0.0/16"
+	withExcept := base
+	withExcept.Except = []policyinfo.NetworkAddress{"10.1.0.0/16"}
+
+	for _, tc := range []struct {
+		name string
+		a, b policyinfo.EndpointInfo
+	}{
+		{"domain only vs domain+cidr", base, withCIDR},
+		{"differing cidr", withCIDR, otherCIDR},
+		{"domain only vs domain+except", base, withExcept},
+	} {
+		if m.getEndpointInfoKey(tc.a) == m.getEndpointInfoKey(tc.b) {
+			t.Errorf("%s: share an endpoint key", tc.name)
+		}
+		if getCombineKey(tc.a) == getCombineKey(tc.b) {
+			t.Errorf("%s: share a combine key", tc.name)
+		}
+	}
+
+	cidrOnly := policyinfo.EndpointInfo{CIDR: "example.com"}
+	if m.getEndpointInfoKey(base) == m.getEndpointInfoKey(cidrOnly) {
+		t.Error("domain and CIDR fields are interchangeable")
+	}
+	if getCombineKey(base) == getCombineKey(cidrOnly) {
+		t.Error("domain and CIDR fields are interchangeable in the combine key")
+	}
+}
+
+func BenchmarkClusterEndpointInfoKey(b *testing.B) {
+	m := &policyEndpointsManager{}
+	tcp := corev1.ProtocolTCP
+	for _, n := range []int{1, 16} {
+		ports := make([]policyinfo.Port, 0, n)
+		for i := 0; i < n; i++ {
+			p, e := int32(1000+i), int32(2000+i)
+			ports = append(ports, policyinfo.Port{Protocol: &tcp, Port: &p, EndPort: &e})
+		}
+		info := policyinfo.ClusterEndpointInfo{CIDR: "10.200.0.0/16", Action: "Deny", Ports: ports}
+		b.Run(fmt.Sprintf("%dports", n), func(b *testing.B) {
+			for b.Loop() {
+				m.getClusterEndpointInfoKey(info)
+			}
+		})
+	}
+}

--- a/pkg/policyendpoints/manager.go
+++ b/pkg/policyendpoints/manager.go
@@ -2,11 +2,7 @@ package policyendpoints
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
-	"sort"
-	"strconv"
 	"time"
 
 	"golang.org/x/exp/maps"
@@ -332,26 +328,13 @@ func (m *policyEndpointsManager) processPolicyEndpoints(pes []policyinfo.PolicyE
 	return newPEs
 }
 
-// getCombineKey creates a combining key from CIDR or DomainName and sorted exceptions,
-// excluding ports so that entries with the same network identity get merged.
+// getCombineKey identifies a peer for port merging: every field except Ports.
 func getCombineKey(ep policyinfo.EndpointInfo) string {
-	var key string
-	if ep.DomainName != "" {
-		key = "fqdn|" + string(ep.DomainName) + "|"
-	} else {
-		key = "cidr|" + string(ep.CIDR) + "|"
-	}
-
-	sortedExcepts := make([]policyinfo.NetworkAddress, len(ep.Except))
-	copy(sortedExcepts, ep.Except)
-	sort.Slice(sortedExcepts, func(i, j int) bool {
-		return string(sortedExcepts[i]) < string(sortedExcepts[j])
-	})
-	for _, except := range sortedExcepts {
-		key += string(except) + "|"
-	}
-
-	return key
+	w := newHashKeyWriter()
+	w.str("cidr", string(ep.CIDR))
+	w.strs("except", ep.Except)
+	w.str("domain", string(ep.DomainName))
+	return w.sum()
 }
 
 func combineRulesEndpoints(ingressEndpoints []policyinfo.EndpointInfo) []policyinfo.EndpointInfo {
@@ -432,34 +415,15 @@ func (m *policyEndpointsManager) getListOfEndpointInfoFromHash(hashes []string, 
 	return ruleList
 }
 
-// TODO: this can return different hash for semantically same endpointinfo as port slice order can generate separate hash.
-// Check how its tied in bin packing algo and fix if needed
+// getEndpointInfoKey hashes every field: branching on DomainName would leave
+// CIDR and Except out of the key.
 func (m *policyEndpointsManager) getEndpointInfoKey(info policyinfo.EndpointInfo) string {
-	hasher := sha256.New()
-
-	// Handle FQDN case for ApplicationNetworkPolicy
-	if info.DomainName != "" {
-		hasher.Write([]byte(info.DomainName))
-	} else {
-		// Handle CIDR case for NetworkPolicy
-		hasher.Write([]byte(info.CIDR))
-		for _, except := range info.Except {
-			hasher.Write([]byte(except))
-		}
-	}
-
-	for _, port := range info.Ports {
-		if port.Protocol != nil {
-			hasher.Write([]byte(*port.Protocol))
-		}
-		if port.Port != nil {
-			hasher.Write([]byte(strconv.Itoa(int(*port.Port))))
-		}
-		if port.EndPort != nil {
-			hasher.Write([]byte(strconv.Itoa(int(*port.EndPort))))
-		}
-	}
-	return hex.EncodeToString(hasher.Sum(nil))
+	w := newHashKeyWriter()
+	w.str("cidr", string(info.CIDR))
+	w.strs("except", info.Except)
+	w.str("domain", string(info.DomainName))
+	w.ports(info.Ports)
+	return w.sum()
 }
 
 // processExistingPolicyEndpoints processes the existing policies with the incoming policy changes
@@ -497,19 +461,20 @@ func (m *policyEndpointsManager) processExistingPolicyEndpoints(
 	// in modified and potential delete candidate lists. We only create new PolicyEndpoint resources if we exhaust all the existing resources.
 	// Any PolicyEndpoint resources placed in potentialDelete bucket that aren't utilized at the end of the binpacking flow will be permanently deleted.
 	for i := range existingPolicyEndpoints {
+		// Keep the desired copy; a key match need not imply equality.
 		ingEndpointList := make([]policyinfo.EndpointInfo, 0, len(existingPolicyEndpoints[i].Spec.Ingress))
 		for _, ingRule := range existingPolicyEndpoints[i].Spec.Ingress {
 			ruleKey := m.getEndpointInfoKey(ingRule)
-			if _, exists := ingressEndpointsMap[ruleKey]; exists {
-				ingEndpointList = append(ingEndpointList, ingRule)
+			if desired, exists := ingressEndpointsMap[ruleKey]; exists {
+				ingEndpointList = append(ingEndpointList, *desired.DeepCopy())
 				delete(ingressEndpointsMap, ruleKey)
 			}
 		}
 		egEndpointList := make([]policyinfo.EndpointInfo, 0, len(existingPolicyEndpoints[i].Spec.Egress))
 		for _, egRule := range existingPolicyEndpoints[i].Spec.Egress {
 			ruleKey := m.getEndpointInfoKey(egRule)
-			if _, exists := egressEndpointsMap[ruleKey]; exists {
-				egEndpointList = append(egEndpointList, egRule)
+			if desired, exists := egressEndpointsMap[ruleKey]; exists {
+				egEndpointList = append(egEndpointList, *desired.DeepCopy())
 				delete(egressEndpointsMap, ruleKey)
 			}
 		}
@@ -531,8 +496,11 @@ func (m *policyEndpointsManager) processExistingPolicyEndpoints(
 			existingPolicyEndpoints[i].Spec.Egress = egEndpointList
 			existingPolicyEndpoints[i].Spec.PodSelectorEndpoints = podSelectorEndpointList
 			potentialDeletes = append(potentialDeletes, existingPolicyEndpoints[i])
-		} else if len(existingPolicyEndpoints[i].Spec.Ingress) != len(ingEndpointList) || len(existingPolicyEndpoints[i].Spec.Egress) != len(egEndpointList) ||
-			len(existingPolicyEndpoints[i].Spec.PodSelectorEndpoints) != len(podSelectorEndpointList) || policyEndpointChanged {
+		} else if !equality.Semantic.DeepEqual(existingPolicyEndpoints[i].Spec.Ingress, ingEndpointList) ||
+			!equality.Semantic.DeepEqual(existingPolicyEndpoints[i].Spec.Egress, egEndpointList) ||
+			!equality.Semantic.DeepEqual(existingPolicyEndpoints[i].Spec.PodSelectorEndpoints, podSelectorEndpointList) ||
+			policyEndpointChanged {
+			// Content, not length: an in-place edit keeps the count.
 			existingPolicyEndpoints[i].Spec.Ingress = ingEndpointList
 			existingPolicyEndpoints[i].Spec.Egress = egEndpointList
 			existingPolicyEndpoints[i].Spec.PodSelectorEndpoints = podSelectorEndpointList


### PR DESCRIPTION
## What

Endpoint hash keys are used as rule identity in the chunking code, so the key derivation has to be injective. It was not: fields were concatenated without a delimiter, and ports were converted to a string via a rune conversion, which is lossy over part of the input range.

Two distinct rules could therefore derive the same key. A key match was taken as proof of rule equality, and the subsequent change check compared only list lengths, so a rule edited in place could be dropped — leaving the stored `PolicyEndpoint` / `ClusterPolicyEndpoint` holding the previous value with no update written.

## Changes

- Add `hashKeyWriter`, which tags every field, length-prefixes every variable-length value, and renders integers as decimal digits.
- Rewrite `getClusterEndpointInfoKey` and `getEndpointInfoKey` to use it, covering both the ClusterNetworkPolicy and the namespaced NetworkPolicy / ANP paths.
- On a key match, keep the desired rule rather than the stored one, so correctness no longer depends on the key being collision-free.
- Compare list contents with `equality.Semantic.DeepEqual` rather than comparing lengths when deciding whether an endpoint object changed. An in-place replacement leaves the count unchanged, so the length check alone would treat it as no change and never persist it.

## Upgrade behavior

Existing objects converge on the first reconcile after upgrade: a stale stored rule no longer key-matches the desired rule, so it is replaced. Rules that are already correct still key-match and are left alone. No migration step is required.

## Testing

New unit tests in `pkg/policyendpoints/hashkey_test.go`:

| Test | Covers |
|---|---|
| `TestClusterKeyInjectiveOverPortSpace` | every port in 1..65535 maps to a distinct key |
| `TestClusterKeyHighPortsDiffer` | port pairs that previously shared a key |
| `TestKeyFieldsCannotAlias` | one field's value cannot absorb the next |
| `TestNamespacedKeyPortRangesCannotAlias` | adjacent numeric fields do not run together; CIDR does not absorb an `Except` entry |
| `TestInPlacePortEditReachesCPE` | an in-place port edit reaches the persisted CPE via `computeClusterPolicyEndpoints` |

```
--- PASS: TestClusterKeyInjectiveOverPortSpace (0.08s)
--- PASS: TestClusterKeyHighPortsDiffer (0.00s)
--- PASS: TestKeyFieldsCannotAlias (0.00s)
--- PASS: TestNamespacedKeyPortRangesCannotAlias (0.00s)
--- PASS: TestInPlacePortEditReachesCPE (0.00s)
```

All five fail on unmodified source and pass with this change. `go test ./...` and `go vet ./...` are clean; the existing `pkg/policyendpoints` and `internal/controllers` suites still pass.

## Notes

Not addressed here: the pre-existing `TODO` on `getEndpointInfoKey` about port-slice ordering producing different keys for semantically equal rules. With the content comparison in place that now causes a converging rewrite rather than stale state, so it is left for a separate change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.