### PR TITLE
Filter headless Services from the informer cache

### DIFF
--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -113,6 +113,12 @@ func podCacheFieldSelector() fields.Selector {
 	)
 }
 
+// serviceCacheFieldSelector drops headless Services from the informer cache.
+// Consumers already skip ClusterIPNone, so listing them is wasted work.
+func serviceCacheFieldSelector() fields.Selector {
+	return fields.OneTermNotEqualSelector("spec.clusterIP", corev1.ClusterIPNone)
+}
+
 // BuildCacheOptions returns a cache.Options struct for this controller.
 func BuildCacheOptions() cache.Options {
 	cacheOptions := cache.Options{
@@ -124,6 +130,7 @@ func BuildCacheOptions() cache.Options {
 			},
 			&corev1.Service{}: {
 				Transform: k8s.StripDownServiceTransformFunc,
+				Field:     serviceCacheFieldSelector(),
 			},
 			&corev1.Namespace{}:                  {},
 			&networkingv1.NetworkPolicy{}:        {},

--- a/pkg/config/runtime_config_test.go
+++ b/pkg/config/runtime_config_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func Test_buildCacheOptions(t *testing.T) {
@@ -11,4 +12,13 @@ func Test_buildCacheOptions(t *testing.T) {
 	g := NewWithT(t)
 	g.Expect(cacheOptions.ReaderFailOnMissingInformer).To(BeTrue())
 	g.Expect(cacheOptions.ByObject).To(HaveLen(8))
+
+	var svcField string
+	for obj, cfg := range cacheOptions.ByObject {
+		if _, ok := obj.(*corev1.Service); ok {
+			g.Expect(cfg.Field).ToNot(BeNil())
+			svcField = cfg.Field.String()
+		}
+	}
+	g.Expect(svcField).To(Equal("spec.clusterIP!=" + corev1.ClusterIPNone))
 }


### PR DESCRIPTION
What type of PR is this?

cleanup

Which issue does this PR fix:

Closes #258

What does this PR do / Why do we need it:

Headless Services are already skipped by consumers. Filtering them with a server side field selector keeps them out of the informer cache so the initial list and watch stay smaller.

Testing done on this change:

go test ./pkg/config/

Automation added to e2e:

No

Will this PR introduce any new dependencies?:

No

Will this break upgrades or downgrades. Has updating a running cluster been tested?:

No. Existing clusters keep the same PolicyEndpoint behavior because headless Services were already ignored.

Does this PR introduce any user facing change?:

No